### PR TITLE
feat: Add parser download script and CI setup for reliable tests

### DIFF
--- a/CI_PARSER_SETUP.md
+++ b/CI_PARSER_SETUP.md
@@ -1,0 +1,92 @@
+# CI Parser Setup Instructions
+
+## Problem
+
+Tests skip when tree-sitter parsers are not installed, leading to false-green builds in CI.
+
+## Solution
+
+Add a step to download parsers before running tests in your CI workflow.
+
+## Required Changes to `.github/workflows/ci.yml`
+
+Add the following step **before** the "Run tests" step:
+
+```yaml
+- name: Setup parsers for tests
+  run: bundle exec rake parsers:download
+```
+
+### Complete Example
+
+```yaml
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby-version: ['3.3', '3.4', '4.0']
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Ruby ${{ matrix.ruby-version }}
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+          bundler-cache: true
+
+      - name: Setup parsers for tests
+        run: bundle exec rake parsers:download
+
+      - name: Run tests
+        run: bundle exec rake test
+```
+
+## Available Rake Tasks
+
+- `rake parsers:download` - Download prebuilt parsers (fastest, recommended for CI)
+- `rake parsers:build` - Build parsers from source (requires compiler)
+- `rake parsers:setup` - Download if possible, fall back to build
+
+## Parsers Required for Tests
+
+- `ruby` - For Ruby syntax highlighting tests
+- `hcl` - For HCL/Terraform tests
+- `markdown` - For Markdown integration tests
+
+## Manual Setup (Development)
+
+To run tests locally with parsers:
+
+```bash
+bundle exec rake parsers:download
+bundle exec rake test
+```
+
+Or build from source:
+
+```bash
+./scripts/build_parsers.sh
+bundle exec rake test
+```
+
+## Troubleshooting
+
+If parser download fails in CI:
+1. Check network connectivity to GitHub
+2. Verify the Faveod/tree-sitter-parsers release version in `scripts/download_parsers.sh`
+3. Fall back to building from source: `bundle exec rake parsers:build`
+
+## References
+
+- Issue: #20
+- Parser source: https://github.com/Faveod/tree-sitter-parsers

--- a/Rakefile
+++ b/Rakefile
@@ -9,4 +9,21 @@ Rake::TestTask.new(:test) do |t|
   t.test_files = FileList["test/**/test_*.rb"]
 end
 
+namespace :parsers do
+  desc "Download prebuilt parsers for CI (ruby, hcl, markdown)"
+  task :download do
+    sh "bash scripts/download_parsers.sh ruby hcl markdown"
+  end
+
+  desc "Build parsers from source (HCL, Ruby)"
+  task :build do
+    sh "bash scripts/build_parsers.sh"
+  end
+
+  desc "Setup parsers for testing (downloads if available, falls back to build)"
+  task :setup do
+    sh "bash scripts/download_parsers.sh ruby hcl markdown || bash scripts/build_parsers.sh"
+  end
+end
+
 task default: :test

--- a/scripts/download_parsers.sh
+++ b/scripts/download_parsers.sh
@@ -1,0 +1,121 @@
+#!/bin/bash
+set -euo pipefail
+
+# Parser ダウンロードスクリプト（CI 用）
+# Usage: ./scripts/download_parsers.sh [languages...]
+#   languages: ダウンロードする言語（省略時は ruby, hcl, markdown）
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+
+# プラットフォーム判定
+if [[ "$(uname)" == "Darwin" ]]; then
+  if [[ "$(uname -m)" == "arm64" ]]; then
+    PLATFORM="darwin-arm64"
+    EXT=".dylib"
+  else
+    PLATFORM="darwin-x64"
+    EXT=".dylib"
+  fi
+else
+  if [[ "$(uname -m)" == "aarch64" ]]; then
+    PLATFORM="linux-arm64"
+    EXT=".so"
+  else
+    PLATFORM="linux-x64"
+    EXT=".so"
+  fi
+fi
+
+PARSER_DIR="$PROJECT_DIR/parsers/$PLATFORM"
+mkdir -p "$PARSER_DIR"
+
+echo "Downloading parsers for $PLATFORM..."
+
+# デフォルトの言語リスト
+if [[ $# -eq 0 ]]; then
+  LANGUAGES=("ruby" "markdown")
+else
+  LANGUAGES=("$@")
+fi
+
+# Faveod/tree-sitter-parsers のリリースバージョン
+RELEASE_VERSION="v0.1.0"
+BASE_URL="https://github.com/Faveod/tree-sitter-parsers/releases/download/$RELEASE_VERSION"
+
+download_parser() {
+  local lang=$1
+  local filename="libtree-sitter-${lang}${EXT}"
+  local url="${BASE_URL}/libtree-sitter-${lang}-${PLATFORM}${EXT}"
+  local dest="$PARSER_DIR/$filename"
+
+  echo "Downloading $lang parser..."
+  echo "  URL: $url"
+
+  if curl -fsSL -o "$dest" "$url"; then
+    if [[ -s "$dest" ]]; then
+      echo "✓ $lang parser installed to $dest"
+      return 0
+    else
+      echo "✗ Downloaded file is empty"
+      rm -f "$dest"
+      return 1
+    fi
+  else
+    echo "✗ Warning: Could not download $lang parser from $url"
+    return 1
+  fi
+}
+
+build_hcl_parser() {
+  echo "Building HCL parser from source..."
+  TMP_DIR=$(mktemp -d)
+  trap "rm -rf $TMP_DIR" RETURN
+
+  cd "$TMP_DIR"
+  if git clone --depth 1 https://github.com/mitchellh/tree-sitter-hcl.git 2>/dev/null; then
+    cd tree-sitter-hcl
+    if c++ -shared -fPIC -O2 -std=c++14 -Isrc src/parser.c src/scanner.cc -o "libtree-sitter-hcl${EXT}" 2>/dev/null; then
+      cp "libtree-sitter-hcl${EXT}" "$PARSER_DIR/"
+      echo "✓ HCL parser built and installed"
+      return 0
+    fi
+  fi
+  echo "✗ Failed to build HCL parser"
+  return 1
+}
+
+# 各言語のパーサーをダウンロード
+SUCCESS_COUNT=0
+FAIL_COUNT=0
+
+for lang in "${LANGUAGES[@]}"; do
+  # HCL は Faveod にないのでビルド
+  if [[ "$lang" == "hcl" ]]; then
+    if build_hcl_parser; then
+      ((SUCCESS_COUNT++)) || true
+    else
+      ((FAIL_COUNT++)) || true
+    fi
+  else
+    if download_parser "$lang"; then
+      ((SUCCESS_COUNT++)) || true
+    else
+      ((FAIL_COUNT++)) || true
+    fi
+  fi
+done
+
+echo ""
+echo "Download complete: $SUCCESS_COUNT succeeded, $FAIL_COUNT failed"
+echo "Parsers in $PARSER_DIR:"
+ls -lh "$PARSER_DIR" | grep -v "^total" | grep -v ".gitkeep" || echo "(no parsers)"
+
+if [[ $FAIL_COUNT -gt 0 ]]; then
+  echo ""
+  echo "Note: Some parsers failed to download. You may need to build them from source."
+  echo "Run: ./scripts/build_parsers.sh"
+  exit 1
+fi
+
+exit 0


### PR DESCRIPTION
## Summary

Adds infrastructure to download and setup tree-sitter parsers in CI, ensuring tests run reliably without being skipped.

## Changes

- ✨ Add `scripts/download_parsers.sh` to download prebuilt parsers
- ✨ Add Rake tasks for parser management (`parsers:download`, `parsers:build`, `parsers:setup`)
- 📝 Add `CI_PARSER_SETUP.md` with workflow integration instructions

## How It Works

The solution provides:
1. A script that downloads ruby/markdown parsers from Faveod/tree-sitter-parsers
2. Builds HCL parser from source (not available in Faveod)
3. Rake tasks for easy CI integration

CI workflow needs one additional step:
```yaml
- name: Setup parsers for tests
  run: bundle exec rake parsers:download
```

See `CI_PARSER_SETUP.md` for complete instructions.

## Testing

Locally:
```bash
bundle exec rake parsers:download
bundle exec rake test
```

Closes #20

Generated with [Claude Code](https://claude.ai/code)