### PR TITLE
feat: Add Elixir language support

### DIFF
--- a/exe/textbringer-tree-sitter
+++ b/exe/textbringer-tree-sitter
@@ -71,6 +71,13 @@ module TextbringerTreeSitterCLI
       build_cmd: ->(src_dir, out_file) {
         "cc -shared -fPIC -O2 -I#{src_dir}/src #{src_dir}/src/parser.c #{src_dir}/src/scanner.c -o #{out_file}"
       }
+    },
+    elixir: {
+      repo: "elixir-lang/tree-sitter-elixir",
+      branch: "main",
+      build_cmd: ->(src_dir, out_file) {
+        "cc -shared -fPIC -O2 -I#{src_dir}/src #{src_dir}/src/parser.c #{src_dir}/src/scanner.c -o #{out_file}"
+      }
     }
   }.freeze
 
@@ -485,7 +492,7 @@ module TextbringerTreeSitterCLI
         if success && !skip_map
           # デフォルト node_map がある言語はスキップ
           default_node_map_languages = %w[
-            bash c cobol csharp groovy haml hcl html java javascript
+            bash c cobol csharp elixir groovy haml hcl html java javascript
             json pascal php python ruby rust sql yaml
           ]
           lang_normalized = lang.to_s.gsub("-", "")

--- a/lib/textbringer/tree_sitter/node_maps.rb
+++ b/lib/textbringer/tree_sitter/node_maps.rb
@@ -6,6 +6,7 @@ require_relative "node_maps/bash"
 require_relative "node_maps/c"
 require_relative "node_maps/csharp"
 require_relative "node_maps/cobol"
+require_relative "node_maps/elixir"
 require_relative "node_maps/groovy"
 require_relative "node_maps/haml"
 require_relative "node_maps/html"
@@ -60,6 +61,7 @@ module Textbringer
             c: C,
             csharp: CSHARP,
             cobol: COBOL,
+            elixir: ELIXIR,
             groovy: GROOVY,
             haml: HAML,
             html: HTML,

--- a/lib/textbringer/tree_sitter/node_maps/elixir.rb
+++ b/lib/textbringer/tree_sitter/node_maps/elixir.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+module Textbringer
+  module TreeSitter
+    module NodeMaps
+      # Feature-based ノードマッピング for Elixir
+      ELIXIR_FEATURES = {
+        comment: %i[comment],
+        string: %i[
+          string
+          quoted_content
+          charlist
+          sigil
+          atom
+          quoted_atom
+          interpolation
+          escape_sequence
+        ],
+        keyword: %i[
+          do
+          end
+          def
+          defp
+          defmodule
+          defmacro
+          defmacrop
+          defstruct
+          defimpl
+          defprotocol
+          if
+          else
+          unless
+          cond
+          case
+          when
+          fn
+          for
+          with
+          receive
+          after
+          rescue
+          catch
+          raise
+          try
+          quote
+          unquote
+          import
+          require
+          alias
+          use
+        ],
+        number: %i[integer float],
+        constant: %i[
+          boolean
+          nil
+          atom
+          module
+        ],
+        function_name: %i[
+          call
+          identifier
+        ],
+        variable: %i[
+          identifier
+        ],
+        operator: %i[
+          operator
+          binary_operator
+          unary_operator
+          arrow
+          pipe
+          range
+          stab_clause
+        ],
+        punctuation: %i[],
+        builtin: %i[true false nil],
+        property: %i[
+          list
+          tuple
+          map
+          keyword_list
+          struct
+          bitstring
+        ]
+      }.freeze
+
+      # Feature → Face の展開
+      ELIXIR = ELIXIR_FEATURES.flat_map { |face, nodes|
+        nodes.map { |node| [node, face] }
+      }.to_h.freeze
+    end
+  end
+end

--- a/lib/textbringer_plugin.rb
+++ b/lib/textbringer_plugin.rb
@@ -53,6 +53,7 @@ MODE_LANGUAGE_MAP = {
   "TypeScriptMode" => :typescript,
   "TSXMode" => :tsx,
   "SQLMode" => :sql,
+  "ElixirMode" => :elixir,
 }.freeze
 
 # 言語 → ファイルパターン（自動 Mode 生成用）
@@ -73,6 +74,7 @@ LANGUAGE_FILE_PATTERNS = {
   bash: /\.(sh|bash)$/i,
   php: /\.php$/i,
   html: /\.html?$/i,
+  elixir: /\.(ex|exs)$/i,
 }.freeze
 
 # parser + node_map がある言語で、Mode がなければ自動生成


### PR DESCRIPTION
## Summary

This PR adds Elixir language support to textbringer-tree-sitter as requested in #22.

## Changes

- Add Elixir parser configuration to BUILD_PARSERS
- Add ElixirMode mapping in MODE_LANGUAGE_MAP
- Add file pattern for .ex and .exs files
- Create node_maps/elixir.rb with comprehensive Elixir syntax mappings
- Add elixir to default node_map languages list

## Parser Info

- Repository: elixir-lang/tree-sitter-elixir
- Branch: main
- Build: Includes both parser.c and scanner.c

Closes #22

---
Generated with [Claude Code](https://claude.ai/code)