### PR TITLE
feat: Add Zig language support

### DIFF
--- a/exe/textbringer-tree-sitter
+++ b/exe/textbringer-tree-sitter
@@ -86,6 +86,13 @@ module TextbringerTreeSitterCLI
       build_cmd: ->(src_dir, out_file) {
         "cc -shared -fPIC -O2 -I#{src_dir}/src #{src_dir}/src/parser.c -o #{out_file}"
       }
+    },
+    zig: {
+      repo: "tree-sitter-grammars/tree-sitter-zig",
+      branch: "master",
+      build_cmd: ->(src_dir, out_file) {
+        "cc -shared -fPIC -O2 -I#{src_dir}/src #{src_dir}/src/parser.c -o #{out_file}"
+      }
     }
   }.freeze
 

--- a/lib/textbringer_plugin.rb
+++ b/lib/textbringer_plugin.rb
@@ -55,6 +55,7 @@ MODE_LANGUAGE_MAP = {
   "SQLMode" => :sql,
   "ElixirMode" => :elixir,
   "KotlinMode" => :kotlin,
+  "ZigMode" => :zig,
 }.freeze
 
 # 言語 → ファイルパターン（自動 Mode 生成用）
@@ -77,6 +78,7 @@ LANGUAGE_FILE_PATTERNS = {
   html: /\.html?$/i,
   elixir: /\.(ex|exs)$/i,
   kotlin: /\.(kt|kts)$/i,
+  zig: /\.zig$/i,
 }.freeze
 
 # parser + node_map がある言語で、Mode がなければ自動生成


### PR DESCRIPTION
## Summary

Adds tree-sitter parser support for Zig programming language.

## Changes

- Added Zig parser configuration to BUILD_PARSERS in `exe/textbringer-tree-sitter`
- Added ZigMode to MODE_LANGUAGE_MAP in `lib/textbringer_plugin.rb`
- Added .zig file pattern to LANGUAGE_FILE_PATTERNS

## Usage

```bash
textbringer-tree-sitter get zig
ls ~/.textbringer/parsers/*/libtree-sitter-zig.*
```

Closes #27

Generated with [Claude Code](https://claude.ai/code)