### PR TITLE
Add Crystal language support

### DIFF
--- a/exe/textbringer-tree-sitter
+++ b/exe/textbringer-tree-sitter
@@ -73,6 +73,13 @@ module TextbringerTreeSitterCLI
         "cc -shared -fPIC -O2 -I#{src_dir}/src #{src_dir}/src/parser.c #{src_dir}/src/scanner.c -o #{out_file}"
       }
     },
+    crystal: {
+      repo: "crystal-lang-tools/tree-sitter-crystal",
+      branch: "main",
+      build_cmd: ->(src_dir, out_file) {
+        "cc -shared -fPIC -O2 -I#{src_dir}/src #{src_dir}/src/parser.c #{src_dir}/src/scanner.c -o #{out_file}"
+      }
+    },
     elixir: {
       repo: "elixir-lang/tree-sitter-elixir",
       branch: "main",
@@ -742,7 +749,11 @@ module TextbringerTreeSitterCLI
         if success && !skip_map
           # デフォルト node_map がある言語はスキップ
           default_node_map_languages = %w[
+<<<<<<< HEAD
             bash c cobol csharp elixir groovy haml hcl html java javascript
+=======
+            bash c cobol crystal csharp groovy haml hcl html java javascript
+>>>>>>> b92ff87 (Add Crystal language support)
             json pascal php python ruby rust sql yaml
           ]
           lang_normalized = lang.to_s.gsub("-", "")

--- a/lib/textbringer/tree_sitter/node_maps.rb
+++ b/lib/textbringer/tree_sitter/node_maps.rb
@@ -6,6 +6,7 @@ require_relative "node_maps/bash"
 require_relative "node_maps/c"
 require_relative "node_maps/csharp"
 require_relative "node_maps/cobol"
+require_relative "node_maps/crystal"
 require_relative "node_maps/elixir"
 require_relative "node_maps/groovy"
 require_relative "node_maps/haml"
@@ -61,6 +62,7 @@ module Textbringer
             c: C,
             csharp: CSHARP,
             cobol: COBOL,
+            crystal: CRYSTAL,
             elixir: ELIXIR,
             groovy: GROOVY,
             haml: HAML,

--- a/lib/textbringer/tree_sitter/node_maps/crystal.rb
+++ b/lib/textbringer/tree_sitter/node_maps/crystal.rb
@@ -1,0 +1,144 @@
+# frozen_string_literal: true
+
+module Textbringer
+  module TreeSitter
+    module NodeMaps
+      # Crystal language node mapping
+      # Based on crystal-lang-tools/tree-sitter-crystal
+      # Crystal has Ruby-like syntax with static typing
+      CRYSTAL_FEATURES = {
+        comment: %i[comment],
+        string: %i[
+          string
+          string_literal
+          string_content
+          heredoc_content
+          heredoc_body
+          symbol
+          simple_symbol
+          char_literal
+          escape_sequence
+          regex
+          regex_literal
+          command
+        ],
+        keyword: %i[
+          def
+          end
+          class
+          module
+          struct
+          if
+          else
+          elsif
+          unless
+          case
+          when
+          then
+          while
+          until
+          for
+          do
+          break
+          next
+          redo
+          return
+          yield
+          begin
+          rescue
+          ensure
+          and
+          or
+          not
+          in
+          alias
+          abstract
+          private
+          protected
+          getter
+          setter
+          property
+          include
+          extend
+          require
+          lib
+          fun
+          macro
+          annotation
+          self
+          super
+          nil
+          true
+          false
+          typeof
+          sizeof
+          offsetof
+          pointerof
+          as
+          is_a?
+          responds_to?
+          uninitialized
+          out
+          with
+        ],
+        number: %i[
+          integer
+          float
+          number_literal
+          integer_literal
+          float_literal
+        ],
+        constant: %i[
+          constant
+          type_identifier
+          class_name
+        ],
+        function_name: %i[
+          method
+          method_name
+          function_identifier
+          call
+        ],
+        variable: %i[
+          identifier
+          instance_variable
+          class_variable
+          global_variable
+          parameter
+          variable
+        ],
+        type: %i[
+          type
+          generic_type
+          union_type
+          nilable_type
+          proc_type
+          tuple_type
+        ],
+        operator: %i[
+          binary
+          unary
+          assignment
+          operator
+          binary_operator
+          unary_operator
+        ],
+        punctuation: %i[],
+        builtin: %i[],
+        property: %i[
+          hash
+          array
+          tuple
+          named_tuple
+          block
+          attribute
+        ]
+      }.freeze
+
+      # Feature → Face の展開
+      CRYSTAL = CRYSTAL_FEATURES.flat_map { |face, nodes|
+        nodes.map { |node| [node, face] }
+      }.to_h.freeze
+    end
+  end
+end

--- a/lib/textbringer_plugin.rb
+++ b/lib/textbringer_plugin.rb
@@ -56,6 +56,7 @@ MODE_LANGUAGE_MAP = {
   "ElixirMode" => :elixir,
   "KotlinMode" => :kotlin,
   "ZigMode" => :zig,
+  "CrystalMode" => :crystal,
 }.freeze
 
 # 言語 → ファイルパターン（自動 Mode 生成用）
@@ -79,6 +80,7 @@ LANGUAGE_FILE_PATTERNS = {
   elixir: /\.(ex|exs)$/i,
   kotlin: /\.(kt|kts)$/i,
   zig: /\.zig$/i,
+  crystal: /\.cr$/i,
 }.freeze
 
 # parser + node_map がある言語で、Mode がなければ自動生成


### PR DESCRIPTION
## Summary

Adds tree-sitter parser support for Crystal programming language.

## Changes

- Add Crystal to BUILD_PARSERS with crystal-lang-tools/tree-sitter-crystal
- Add CrystalMode to MODE_LANGUAGE_MAP
- Add .cr file pattern recognition
- Create Crystal node_map with Ruby-like syntax highlighting
- Update node_maps.rb to include Crystal in default maps

## Testing

Users can test by running:
```bash
textbringer-tree-sitter get crystal
ls ~/.textbringer/parsers/*/libtree-sitter-crystal.*
```

Fixes #26

Generated with [Claude Code](https://claude.ai/code)