### PR TITLE
feat: Add Swift language support

### DIFF
--- a/exe/textbringer-tree-sitter
+++ b/exe/textbringer-tree-sitter
@@ -94,6 +94,13 @@ module TextbringerTreeSitterCLI
         "cc -shared -fPIC -O2 -I#{src_dir}/src #{src_dir}/src/parser.c -o #{out_file}"
       }
     },
+    swift: {
+      repo: "alex-pinkus/tree-sitter-swift",
+      branch: "main",
+      build_cmd: ->(src_dir, out_file) {
+        "cc -shared -fPIC -O2 -I#{src_dir}/src #{src_dir}/src/parser.c -o #{out_file}"
+      }
+    },
     zig: {
       repo: "tree-sitter-grammars/tree-sitter-zig",
       branch: "master",
@@ -750,11 +757,16 @@ module TextbringerTreeSitterCLI
           # デフォルト node_map がある言語はスキップ
           default_node_map_languages = %w[
 <<<<<<< HEAD
+<<<<<<< HEAD
             bash c cobol csharp elixir groovy haml hcl html java javascript
 =======
             bash c cobol crystal csharp groovy haml hcl html java javascript
 >>>>>>> b92ff87 (Add Crystal language support)
             json pascal php python ruby rust sql yaml
+=======
+            bash c cobol csharp groovy haml hcl html java javascript
+            json pascal php python ruby rust sql swift yaml
+>>>>>>> f8a227e (feat: Add Swift language support)
           ]
           lang_normalized = lang.to_s.gsub("-", "")
           if default_node_map_languages.include?(lang_normalized)

--- a/lib/textbringer/tree_sitter/node_maps.rb
+++ b/lib/textbringer/tree_sitter/node_maps.rb
@@ -19,6 +19,7 @@ require_relative "node_maps/php"
 require_relative "node_maps/python"
 require_relative "node_maps/rust"
 require_relative "node_maps/sql"
+require_relative "node_maps/swift"
 require_relative "node_maps/yaml"
 
 module Textbringer
@@ -75,6 +76,7 @@ module Textbringer
             python: PYTHON,
             rust: RUST,
             sql: SQL,
+            swift: SWIFT,
             yaml: YAML_LANG
           }
         end

--- a/lib/textbringer/tree_sitter/node_maps/swift.rb
+++ b/lib/textbringer/tree_sitter/node_maps/swift.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+module Textbringer
+  module TreeSitter
+    module NodeMaps
+      SWIFT_FEATURES = {
+        comment: %i[
+          comment
+          line_comment
+          block_comment
+          multiline_comment
+        ],
+        string: %i[
+          line_string_literal
+          multi_line_string_literal
+          raw_string_literal
+          string_literal
+          interpolated_string_literal
+        ],
+        keyword: %i[
+          if
+          else
+          switch
+          case
+          default
+          for
+          while
+          repeat
+          break
+          continue
+          return
+          func
+          var
+          let
+          class
+          struct
+          enum
+          protocol
+          extension
+          typealias
+          import
+          init
+          deinit
+          subscript
+          static
+          final
+          override
+          mutating
+          nonmutating
+          convenience
+          required
+          lazy
+          private
+          fileprivate
+          internal
+          public
+          open
+          weak
+          unowned
+          throws
+          rethrows
+          try
+          catch
+          guard
+          defer
+          do
+          where
+          in
+          inout
+          associatedtype
+          precedencegroup
+          operator
+          prefix
+          postfix
+          infix
+          indirect
+          dynamic
+          optional
+          some
+          any
+          async
+          await
+        ],
+        number: %i[
+          integer_literal
+          float_literal
+          hex_literal
+          oct_literal
+          bin_literal
+        ],
+        constant: %i[],
+        function_name: %i[
+          function_declaration
+          method_declaration
+        ],
+        variable: %i[
+          simple_identifier
+          identifier
+          parameter
+        ],
+        type: %i[
+          type_identifier
+          class_declaration
+          struct_declaration
+          enum_declaration
+          protocol_declaration
+        ],
+        operator: %i[
+          binary_expression
+          prefix_expression
+          postfix_expression
+        ],
+        punctuation: %i[],
+        builtin: %i[
+          nil
+          true
+          false
+          self
+          super
+          Self
+        ],
+        property: %i[
+          property_declaration
+          computed_property
+        ]
+      }.freeze
+
+      SWIFT = SWIFT_FEATURES.flat_map { |face, nodes|
+        nodes.map { |node| [node, face] }
+      }.to_h.freeze
+    end
+  end
+end

--- a/lib/textbringer_plugin.rb
+++ b/lib/textbringer_plugin.rb
@@ -57,6 +57,7 @@ MODE_LANGUAGE_MAP = {
   "KotlinMode" => :kotlin,
   "ZigMode" => :zig,
   "CrystalMode" => :crystal,
+  "SwiftMode" => :swift,
 }.freeze
 
 # 言語 → ファイルパターン（自動 Mode 生成用）
@@ -81,6 +82,7 @@ LANGUAGE_FILE_PATTERNS = {
   kotlin: /\.(kt|kts)$/i,
   zig: /\.zig$/i,
   crystal: /\.cr$/i,
+  swift: /\.swift$/i,
 }.freeze
 
 # parser + node_map がある言語で、Mode がなければ自動生成


### PR DESCRIPTION
Add tree-sitter parser support for Swift programming language.

## Changes
- Add Swift parser to BUILD_PARSERS configuration
- Add SwiftMode to MODE_LANGUAGE_MAP
- Add .swift file pattern
- Create node_maps/swift.rb with comprehensive syntax highlighting

Resolves #24

Generated with [Claude Code](https://claude.ai/code)