### PR TITLE
Add Kotlin language support

### DIFF
--- a/exe/textbringer-tree-sitter
+++ b/exe/textbringer-tree-sitter
@@ -79,6 +79,13 @@ module TextbringerTreeSitterCLI
       build_cmd: ->(src_dir, out_file) {
         "cc -shared -fPIC -O2 -I#{src_dir}/src #{src_dir}/src/parser.c #{src_dir}/src/scanner.c -o #{out_file}"
       }
+    },
+    kotlin: {
+      repo: "fwcd/tree-sitter-kotlin",
+      branch: "main",
+      build_cmd: ->(src_dir, out_file) {
+        "cc -shared -fPIC -O2 -I#{src_dir}/src #{src_dir}/src/parser.c -o #{out_file}"
+      }
     }
   }.freeze
 

--- a/lib/textbringer_plugin.rb
+++ b/lib/textbringer_plugin.rb
@@ -54,6 +54,7 @@ MODE_LANGUAGE_MAP = {
   "TSXMode" => :tsx,
   "SQLMode" => :sql,
   "ElixirMode" => :elixir,
+  "KotlinMode" => :kotlin,
 }.freeze
 
 # 言語 → ファイルパターン（自動 Mode 生成用）
@@ -75,6 +76,7 @@ LANGUAGE_FILE_PATTERNS = {
   php: /\.php$/i,
   html: /\.html?$/i,
   elixir: /\.(ex|exs)$/i,
+  kotlin: /\.(kt|kts)$/i,
 }.freeze
 
 # parser + node_map がある言語で、Mode がなければ自動生成


### PR DESCRIPTION
## Summary

Adds Kotlin language support to textbringer-tree-sitter.

## Changes

- Add Kotlin to BUILD_PARSERS with fwcd/tree-sitter-kotlin
- Add KotlinMode to MODE_LANGUAGE_MAP
- Add .kt and .kts file pattern mappings

Users can now install Kotlin parser using:
```bash
textbringer-tree-sitter get kotlin
```

Resolves #23

---

Generated with [Claude Code](https://claude.ai/code)