### PR TITLE
feat: Add SHA256 checksum verification for parser downloads

### DIFF
--- a/exe/textbringer-tree-sitter
+++ b/exe/textbringer-tree-sitter
@@ -7,6 +7,8 @@ require "rbconfig"
 require "tmpdir"
 require "open3"
 require "yaml"
+require "digest"
+require "json"
 
 module TextbringerTreeSitterCLI
   FAVEOD_VERSION = "v4.11"
@@ -165,6 +167,50 @@ module TextbringerTreeSitterCLI
   end
 
   class << self
+    def checksums_file
+      File.expand_path("~/.textbringer/parsers/checksums.json")
+    end
+
+    def load_checksums
+      return {} unless File.exist?(checksums_file)
+
+      begin
+        JSON.parse(File.read(checksums_file))
+      rescue => e
+        warn "Warning: Failed to load checksums: #{e.message}"
+        {}
+      end
+    end
+
+    def save_checksums(checksums)
+      FileUtils.mkdir_p(File.dirname(checksums_file))
+      File.write(checksums_file, JSON.pretty_generate(checksums))
+    end
+
+    def compute_checksum(file_path)
+      Digest::SHA256.file(file_path).hexdigest
+    end
+
+    def verify_checksum(file_path, url)
+      checksums = load_checksums
+      actual = compute_checksum(file_path)
+
+      if checksums.key?(url)
+        expected = checksums[url]
+        if actual != expected
+          raise "Checksum verification failed for #{url}\n" \
+                "  Expected: #{expected}\n" \
+                "  Got:      #{actual}"
+        end
+        puts "  Checksum verified: #{actual[0..15]}..."
+      else
+        # First download - record checksum
+        checksums[url] = actual
+        save_checksums(checksums)
+        puts "  Checksum recorded: #{actual[0..15]}..."
+      end
+    end
+
     def user_config_file
       File.expand_path("~/.textbringer/tree_sitter/languages.yml")
     end
@@ -275,6 +321,14 @@ module TextbringerTreeSitterCLI
           end
         rescue OpenURI::HTTPError => e
           puts "  Error: Failed to download: #{e.message}"
+          return false
+        end
+
+        # Verify checksum
+        begin
+          verify_checksum(tarball, url)
+        rescue => e
+          puts "  Error: #{e.message}"
           return false
         end
 
@@ -493,6 +547,14 @@ module TextbringerTreeSitterCLI
           end
         rescue OpenURI::HTTPError => e
           puts "  Error: Failed to download: #{e.message}"
+          return
+        end
+
+        # Verify checksum
+        begin
+          verify_checksum(tarball, url)
+        rescue => e
+          puts "  Error: #{e.message}"
           return
         end
 
@@ -756,17 +818,8 @@ module TextbringerTreeSitterCLI
         if success && !skip_map
           # デフォルト node_map がある言語はスキップ
           default_node_map_languages = %w[
-<<<<<<< HEAD
-<<<<<<< HEAD
-            bash c cobol csharp elixir groovy haml hcl html java javascript
-=======
-            bash c cobol crystal csharp groovy haml hcl html java javascript
->>>>>>> b92ff87 (Add Crystal language support)
-            json pascal php python ruby rust sql yaml
-=======
-            bash c cobol csharp groovy haml hcl html java javascript
+            bash c cobol crystal csharp elixir groovy haml hcl html java javascript
             json pascal php python ruby rust sql swift yaml
->>>>>>> f8a227e (feat: Add Swift language support)
           ]
           lang_normalized = lang.to_s.gsub("-", "")
           if default_node_map_languages.include?(lang_normalized)


### PR DESCRIPTION
## Summary

Implements SHA256 checksum verification for parser downloads in both the CLI and gem install hook to address supply-chain security concerns.

## Changes

- Resolve merge conflicts from Swift language support
- Add SHA256 checksum computation and verification functions
- Store checksums in `~/.textbringer/parsers/checksums.json`
- Verify downloads against cached checksums
- Fail with clear error messages when verification fails
- Apply to both `exe/textbringer-tree-sitter` CLI and `ext/textbringer_tree_sitter/extconf.rb`

## Benefits

- Protects against corrupted downloads (data integrity)
- Detects tampering on re-downloads (supply-chain security)
- Clear error messages with both expected and actual checksums
- Non-zero exit codes on verification failure
- Transparent to users - automatic checksum management

Closes #11

---

Generated with [Claude Code](https://claude.ai/code)