### PR TITLE
feat: Add MODE_LANGUAGE_MAP and file patterns for cobol, csharp, groovy, haml, pascal

### DIFF
--- a/lib/textbringer_plugin.rb
+++ b/lib/textbringer_plugin.rb
@@ -58,6 +58,11 @@ MODE_LANGUAGE_MAP = {
   "ZigMode" => :zig,
   "CrystalMode" => :crystal,
   "SwiftMode" => :swift,
+  "CobolMode" => :cobol,
+  "CSharpMode" => :csharp,
+  "GroovyMode" => :groovy,
+  "HamlMode" => :haml,
+  "PascalMode" => :pascal,
 }.freeze
 
 # 言語 → ファイルパターン（自動 Mode 生成用）
@@ -83,6 +88,11 @@ LANGUAGE_FILE_PATTERNS = {
   zig: /\.zig$/i,
   crystal: /\.cr$/i,
   swift: /\.swift$/i,
+  cobol: /\.(cob|cbl|cpy|cobol)$/i,
+  csharp: /\.(cs|csx)$/i,
+  groovy: /\.(groovy|gvy|gy|gradle)$/i,
+  haml: /\.haml$/i,
+  pascal: /\.(pas|pp|p|inc)$/i,
 }.freeze
 
 # parser + node_map がある言語で、Mode がなければ自動生成


### PR DESCRIPTION
This PR expands the `MODE_LANGUAGE_MAP` and `LANGUAGE_FILE_PATTERNS` to include five languages that already have node maps but were not registered in the plugin configuration.

### Changes
- Add CobolMode, CSharpMode, GroovyMode, HamlMode, PascalMode to MODE_LANGUAGE_MAP
- Add corresponding file patterns for each language to LANGUAGE_FILE_PATTERNS

### Impact
With these changes, syntax highlighting will automatically enable when opening files with these extensions (provided the tree-sitter parser is installed). Users no longer need to manually call `use_tree_sitter` for these languages.

Fixes #14

Generated with [Claude Code](https://claude.ai/code)