### PR TITLE
feat: Add opt-out for automatic parser downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,20 @@ The following parsers are **automatically installed** during `gem install`:
 
 These are downloaded from [Faveod/tree-sitter-parsers](https://github.com/Faveod/tree-sitter-parsers) and placed in `~/.textbringer/parsers/{platform}/`.
 
+### Opt-out of Automatic Downloads
+
+To skip automatic parser downloads (useful in offline or restricted environments), set the environment variable:
+
+```bash
+export TEXTBRINGER_TREE_SITTER_NO_DOWNLOAD=1
+gem install textbringer-tree-sitter
+```
+
+When this variable is set:
+- `gem install` will skip automatic parser downloads
+- CLI commands (`get`, `get-all`) will refuse to download with an error message
+- You can still manually place parsers in `~/.textbringer/parsers/{platform}/`
+
 ### Installing Additional Parsers
 
 Use the CLI tool to install additional parsers:

--- a/exe/textbringer-tree-sitter
+++ b/exe/textbringer-tree-sitter
@@ -299,6 +299,16 @@ module TextbringerTreeSitterCLI
     end
 
     def download_faveod_parser(language)
+      # Check for opt-out environment variable
+      if ENV["TEXTBRINGER_TREE_SITTER_NO_DOWNLOAD"]
+        puts "Error: TEXTBRINGER_TREE_SITTER_NO_DOWNLOAD is set - downloads are disabled"
+        puts ""
+        puts "To install manually:"
+        puts "  1. Download from https://github.com/Faveod/tree-sitter-parsers/releases"
+        puts "  2. Extract to #{parser_dir}"
+        return false
+      end
+
       # Faveod tarball から特定の parser をインストール
       filename = "libtree-sitter-#{language}#{dylib_ext}"
       dest_path = File.join(parser_dir, filename)
@@ -366,6 +376,17 @@ module TextbringerTreeSitterCLI
     end
 
     def build_parser_from_config(language, config)
+      # Check for opt-out environment variable
+      if ENV["TEXTBRINGER_TREE_SITTER_NO_DOWNLOAD"]
+        puts "Error: TEXTBRINGER_TREE_SITTER_NO_DOWNLOAD is set - downloads are disabled"
+        puts ""
+        puts "To build manually:"
+        puts "  1. Clone https://github.com/#{config.repo}"
+        puts "  2. Build using the instructions in the repository"
+        puts "  3. Copy the library to #{parser_dir}"
+        return false
+      end
+
       filename = "libtree-sitter-#{language}#{dylib_ext}"
       dest_path = File.join(parser_dir, filename)
 
@@ -530,6 +551,16 @@ module TextbringerTreeSitterCLI
     end
 
     def get_all
+      # Check for opt-out environment variable
+      if ENV["TEXTBRINGER_TREE_SITTER_NO_DOWNLOAD"]
+        puts "Error: TEXTBRINGER_TREE_SITTER_NO_DOWNLOAD is set - downloads are disabled"
+        puts ""
+        puts "To install manually:"
+        puts "  1. Download from https://github.com/Faveod/tree-sitter-parsers/releases"
+        puts "  2. Extract to #{parser_dir}"
+        return
+      end
+
       puts "Installing all Faveod prebuilt parsers..."
       puts ""
 

--- a/ext/textbringer_tree_sitter/extconf.rb
+++ b/ext/textbringer_tree_sitter/extconf.rb
@@ -92,6 +92,17 @@ def verify_checksum(file_path, url)
 end
 
 def download_and_extract_parsers
+  # Check for opt-out environment variable
+  if ENV["TEXTBRINGER_TREE_SITTER_NO_DOWNLOAD"]
+    puts "  Skipping parser download (TEXTBRINGER_TREE_SITTER_NO_DOWNLOAD is set)"
+    puts ""
+    puts "  To install parsers manually:"
+    puts "    1. Download from https://github.com/Faveod/tree-sitter-parsers/releases"
+    puts "    2. Extract to #{PARSER_DIR}"
+    puts "    3. Or use: textbringer-tree-sitter get <lang>"
+    return true
+  end
+
   url = "https://github.com/Faveod/tree-sitter-parsers/releases/download/#{FAVEOD_VERSION}/tree-sitter-parsers-#{FAVEOD_VERSION.delete('v')}-#{faveod_platform}.tar.gz"
 
   puts "  Downloading parsers from Faveod..."


### PR DESCRIPTION
## Summary

Implements opt-out mechanism for automatic parser downloads via environment variable.

## Changes

- Add `TEXTBRINGER_TREE_SITTER_NO_DOWNLOAD=1` environment variable support
- Skip downloads in extconf.rb during gem install when set
- Skip downloads in CLI tool (get, get-all, build) when set
- Provide clear error messages with manual installation instructions
- Update README with opt-out documentation

## Testing

All acceptance criteria met:
- Setting env var skips download in both CLI and extconf without errors
- README documents the opt-out behavior
- Clear messaging when skipping with manual install instructions

Fixes #12

Generated with [Claude Code](https://claude.ai/code)