### PR TITLE
feat: Implement incremental parsing for improved performance

### DIFF
--- a/test/textbringer/test_tree_sitter_adapter.rb
+++ b/test/textbringer/test_tree_sitter_adapter.rb
@@ -244,6 +244,103 @@ class TreeSitterAdapterTest < Minitest::Test
     assert_equal 3, mode.send(:byte_offset_to_char_offset, text, text.bytesize)
   end
 
+  # --- キャッシュ関連テスト ---
+
+  # 同じ内容で2回呼ぶと、2回目はキャッシュが効く
+  def test_get_cached_tree_returns_tree_when_content_unchanged
+    mode = create_test_mode(:ruby)
+    buffer = Textbringer::MockBuffer.new
+    buffer_text = "def hello; end"
+    fake_tree = Object.new
+
+    mode.send(:cache_tree, buffer, fake_tree, buffer_text)
+    result = mode.send(:get_cached_tree, buffer, buffer_text)
+
+    assert_same fake_tree, result
+  end
+
+  # 内容が変わったらキャッシュ無効
+  def test_get_cached_tree_returns_nil_when_content_changed
+    mode = create_test_mode(:ruby)
+    buffer = Textbringer::MockBuffer.new
+    buffer_text_v1 = "def hello; end"
+    buffer_text_v2 = "def world; end"
+    fake_tree = Object.new
+
+    mode.send(:cache_tree, buffer, fake_tree, buffer_text_v1)
+    result = mode.send(:get_cached_tree, buffer, buffer_text_v2)
+
+    assert_nil result
+  end
+
+  # 言語が変わったらキャッシュ無効
+  def test_get_cached_tree_returns_nil_when_language_changed
+    mode_ruby = create_test_mode(:ruby)
+    mode_hcl = create_test_mode(:hcl)
+    buffer = Textbringer::MockBuffer.new
+    buffer_text = "some code"
+    fake_tree = Object.new
+
+    # ruby mode でキャッシュ → hcl mode で取得（言語不一致）
+    # 同じ @tree_cache を共有するために instance variable を移植
+    mode_ruby.send(:cache_tree, buffer, fake_tree, buffer_text)
+    mode_hcl.instance_variable_set(:@tree_cache, mode_ruby.instance_variable_get(:@tree_cache))
+
+    result = mode_hcl.send(:get_cached_tree, buffer, buffer_text)
+    assert_nil result
+  end
+
+  # キャッシュが10を超えたら最古のエントリが evict される
+  def test_cache_tree_evicts_oldest_entry_when_exceeding_limit
+    mode = create_test_mode(:ruby)
+
+    buffers = 11.times.map { Textbringer::MockBuffer.new }
+    buffers.each_with_index do |buf, i|
+      text = "code #{i}"
+      mode.send(:cache_tree, buf, Object.new, text)
+    end
+
+    cache = mode.instance_variable_get(:@tree_cache)
+    assert_equal 10, cache.size
+
+    # 最初に入れた buffer[0] は evict されている
+    first_buffer_id = buffers[0].object_id
+    refute cache.key?(first_buffer_id), "最古のエントリが evict されていない"
+
+    # 最後に入れた buffer[10] は残っている
+    last_buffer_id = buffers[10].object_id
+    assert cache.key?(last_buffer_id), "最新のエントリが消えている"
+  end
+
+  # アクセスしたエントリは LRU 順が更新されて evict されない
+  def test_get_cached_tree_refreshes_lru_order
+    mode = create_test_mode(:ruby)
+
+    # 11 個のバッファを用意
+    buffers = 11.times.map { Textbringer::MockBuffer.new }
+    texts = 11.times.map { |i| "code #{i}" }
+
+    # まず 10 個キャッシュ
+    10.times do |i|
+      mode.send(:cache_tree, buffers[i], Object.new, texts[i])
+    end
+
+    # buffer[0] にアクセスして LRU 順を更新
+    result = mode.send(:get_cached_tree, buffers[0], texts[0])
+    refute_nil result, "buffer[0] のキャッシュが見つからない"
+
+    # 11 個目を追加（eviction 発生）
+    mode.send(:cache_tree, buffers[10], Object.new, texts[10])
+
+    cache = mode.instance_variable_get(:@tree_cache)
+    assert_equal 10, cache.size
+
+    # buffer[0] はアクセス済みなので evict されない
+    assert cache.key?(buffers[0].object_id), "アクセス済みの buffer[0] が evict された"
+    # buffer[1] が最古になって evict される
+    refute cache.key?(buffers[1].object_id), "buffer[1] が evict されていない"
+  end
+
   private
 
   def create_test_mode(language)


### PR DESCRIPTION
Add Tree caching per buffer to enable Tree-sitter incremental parsing, significantly improving performance on large files and frequent edits.

### Changes
- Cache parsed Tree objects per buffer using buffer.object_id as key
- Reuse cached tree in parse_string() for incremental parsing
- Invalidate cache when parser language changes
- Limit cache size to 10 entries to prevent memory leaks
- Add debug logging to track incremental parse usage

Fixes #15

Generated with [Claude Code](https://claude.ai/code)