### PR TITLE
refactor: Extract platform helpers into shared module

### DIFF
--- a/exe/textbringer-tree-sitter
+++ b/exe/textbringer-tree-sitter
@@ -3,7 +3,6 @@
 
 require "fileutils"
 require "open-uri"
-require "rbconfig"
 require "tmpdir"
 require "open3"
 require "yaml"
@@ -12,6 +11,7 @@ require "json"
 
 # Load LanguageAliases for normalization
 require_relative "../lib/textbringer/tree_sitter/language_aliases"
+require_relative "../lib/textbringer/tree_sitter/platform"
 
 module TextbringerTreeSitterCLI
   FAVEOD_VERSION = "v4.11"
@@ -260,36 +260,15 @@ module TextbringerTreeSitterCLI
     end
 
     def platform
-      os = case RbConfig::CONFIG["host_os"]
-           when /darwin/i then "darwin"
-           when /linux/i then "linux"
-           else "unknown"
-           end
-
-      arch = case RbConfig::CONFIG["host_cpu"]
-             when /arm64|aarch64/i then "arm64"
-             when /x86_64|amd64/i then "x64"
-             else "unknown"
-             end
-
-      "#{os}-#{arch}"
+      Textbringer::TreeSitter::Platform.platform
     end
 
     def faveod_platform
-      case platform
-      when "darwin-arm64" then "macos-arm64"
-      when "darwin-x64" then "macos-x64"
-      when "linux-x64" then "linux-x64"
-      when "linux-arm64" then "linux-arm64"
-      else platform
-      end
+      Textbringer::TreeSitter::Platform.faveod_platform
     end
 
     def dylib_ext
-      case RbConfig::CONFIG["host_os"]
-      when /darwin/i then ".dylib"
-      else ".so"
-      end
+      Textbringer::TreeSitter::Platform.dylib_ext
     end
 
     def parser_dir

--- a/ext/textbringer_tree_sitter/extconf.rb
+++ b/ext/textbringer_tree_sitter/extconf.rb
@@ -6,42 +6,21 @@
 
 require "fileutils"
 require "open-uri"
-require "rbconfig"
 require "tmpdir"
 require "digest"
 require "json"
+require_relative "../../lib/textbringer/tree_sitter/platform"
 
 def platform
-  os = case RbConfig::CONFIG["host_os"]
-       when /darwin/i then "darwin"
-       when /linux/i then "linux"
-       else "unknown"
-       end
-
-  arch = case RbConfig::CONFIG["host_cpu"]
-         when /arm64|aarch64/i then "arm64"
-         when /x86_64|amd64/i then "x64"
-         else "unknown"
-         end
-
-  "#{os}-#{arch}"
+  Textbringer::TreeSitter::Platform.platform
 end
 
 def faveod_platform
-  case platform
-  when "darwin-arm64" then "macos-arm64"
-  when "darwin-x64" then "macos-x64"
-  when "linux-x64" then "linux-x64"
-  when "linux-arm64" then "linux-arm64"
-  else platform
-  end
+  Textbringer::TreeSitter::Platform.faveod_platform
 end
 
 def dylib_ext
-  case RbConfig::CONFIG["host_os"]
-  when /darwin/i then ".dylib"
-  else ".so"
-  end
+  Textbringer::TreeSitter::Platform.dylib_ext
 end
 
 PARSER_DIR = File.expand_path("~/.textbringer/parsers/#{platform}")

--- a/lib/textbringer/tree_sitter/platform.rb
+++ b/lib/textbringer/tree_sitter/platform.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "rbconfig"
+
+module Textbringer
+  module TreeSitter
+    module Platform
+      class << self
+        # Detect OS and architecture
+        # @return [String] platform string in format "os-arch" (e.g., "darwin-arm64", "linux-x64")
+        def platform
+          os = case RbConfig::CONFIG["host_os"]
+               when /darwin/i then "darwin"
+               when /linux/i then "linux"
+               else "unknown"
+               end
+
+          arch = case RbConfig::CONFIG["host_cpu"]
+                 when /arm64|aarch64/i then "arm64"
+                 when /x86_64|amd64/i then "x64"
+                 else "unknown"
+                 end
+
+          "#{os}-#{arch}"
+        end
+
+        # Get dynamic library extension for current platform
+        # @return [String] ".dylib" for macOS, ".so" for others
+        def dylib_ext
+          case RbConfig::CONFIG["host_os"]
+          when /darwin/i then ".dylib"
+          else ".so"
+          end
+        end
+
+        # Convert platform string to Faveod naming convention
+        # @return [String] Faveod platform name (e.g., "macos-arm64", "linux-x64")
+        def faveod_platform
+          case platform
+          when "darwin-arm64" then "macos-arm64"
+          when "darwin-x64" then "macos-x64"
+          when "linux-x64" then "linux-x64"
+          when "linux-arm64" then "linux-arm64"
+          else platform
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/textbringer/tree_sitter_config.rb
+++ b/lib/textbringer/tree_sitter_config.rb
@@ -1,32 +1,17 @@
 # frozen_string_literal: true
 
-require "rbconfig"
+require_relative "tree_sitter/platform"
 require_relative "tree_sitter/language_aliases"
 
 module Textbringer
   module TreeSitterConfig
     class << self
       def platform
-        os = case RbConfig::CONFIG["host_os"]
-             when /darwin/i then "darwin"
-             when /linux/i then "linux"
-             else "unknown"
-             end
-
-        arch = case RbConfig::CONFIG["host_cpu"]
-               when /arm64|aarch64/i then "arm64"
-               when /x86_64|amd64/i then "x64"
-               else "unknown"
-               end
-
-        "#{os}-#{arch}"
+        TreeSitter::Platform.platform
       end
 
       def dylib_ext
-        case RbConfig::CONFIG["host_os"]
-        when /darwin/i then ".dylib"
-        else ".so"
-        end
+        TreeSitter::Platform.dylib_ext
       end
 
       # Parser を探索するディレクトリのリスト（優先順位順）


### PR DESCRIPTION
Fixes #19

## Summary

Extracts duplicated platform helper logic into a shared module at `lib/textbringer/tree_sitter/platform.rb`.

## Changes

- Created shared module with platform detection methods
- Updated CLI, config, and extconf to use shared module
- Removed ~85 lines of duplicated code

## Impact

- Single source of truth for platform logic
- Improved maintainability
- Backwards compatible

Generated with [Claude Code](https://claude.ai/code)