### PR TITLE
chore: Use Claude Opus for code review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -39,6 +39,7 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          claude_args: '--model claude-opus-4-6'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 


### PR DESCRIPTION
## Summary
- Claude Code Review ワークフローで使用するモデルを `claude-opus-4-6` に固定
- `claude_args: '--model claude-opus-4-6'` を追加

## Test plan
- [ ] PR マージ後、次回の PR で Review が Opus で実行されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)