### PR TITLE
fix: Avoid shell execution for build commands

### DIFF
--- a/exe/textbringer-tree-sitter
+++ b/exe/textbringer-tree-sitter
@@ -89,35 +89,40 @@ module TextbringerTreeSitterCLI
       repo: "crystal-lang-tools/tree-sitter-crystal",
       branch: "main",
       build_cmd: ->(src_dir, out_file) {
-        "cc -shared -fPIC -O2 -I#{src_dir}/src #{src_dir}/src/parser.c #{src_dir}/src/scanner.c -o #{out_file}"
+        ["cc", "-shared", "-fPIC", "-O2", "-I#{src_dir}/src",
+         "#{src_dir}/src/parser.c", "#{src_dir}/src/scanner.c", "-o", out_file]
       }
     },
     elixir: {
       repo: "elixir-lang/tree-sitter-elixir",
       branch: "main",
       build_cmd: ->(src_dir, out_file) {
-        "cc -shared -fPIC -O2 -I#{src_dir}/src #{src_dir}/src/parser.c #{src_dir}/src/scanner.c -o #{out_file}"
+        ["cc", "-shared", "-fPIC", "-O2", "-I#{src_dir}/src",
+         "#{src_dir}/src/parser.c", "#{src_dir}/src/scanner.c", "-o", out_file]
       }
     },
     kotlin: {
       repo: "fwcd/tree-sitter-kotlin",
       branch: "main",
       build_cmd: ->(src_dir, out_file) {
-        "cc -shared -fPIC -O2 -I#{src_dir}/src #{src_dir}/src/parser.c -o #{out_file}"
+        ["cc", "-shared", "-fPIC", "-O2", "-I#{src_dir}/src",
+         "#{src_dir}/src/parser.c", "-o", out_file]
       }
     },
     swift: {
       repo: "alex-pinkus/tree-sitter-swift",
       branch: "main",
       build_cmd: ->(src_dir, out_file) {
-        "cc -shared -fPIC -O2 -I#{src_dir}/src #{src_dir}/src/parser.c -o #{out_file}"
+        ["cc", "-shared", "-fPIC", "-O2", "-I#{src_dir}/src",
+         "#{src_dir}/src/parser.c", "-o", out_file]
       }
     },
     zig: {
       repo: "tree-sitter-grammars/tree-sitter-zig",
       branch: "master",
       build_cmd: ->(src_dir, out_file) {
-        "cc -shared -fPIC -O2 -I#{src_dir}/src #{src_dir}/src/parser.c -o #{out_file}"
+        ["cc", "-shared", "-fPIC", "-O2", "-I#{src_dir}/src",
+         "#{src_dir}/src/parser.c", "-o", out_file]
       }
     }
   }.freeze
@@ -465,9 +470,11 @@ module TextbringerTreeSitterCLI
         ext = File.extname(scanner)
         compiler = ext == ".cc" ? "c++" : "cc"
         std_flag = ext == ".cc" ? "-std=c++14" : "-std=c99"
-        "#{compiler} -shared -fPIC -O2 #{std_flag} -I#{src_dir}/src #{src_dir}/src/parser.c #{scanner} -o #{out_file}"
+        [compiler, "-shared", "-fPIC", "-O2", std_flag, "-I#{src_dir}/src",
+         "#{src_dir}/src/parser.c", scanner, "-o", out_file]
       else
-        "cc -shared -fPIC -O2 -I#{src_dir}/src #{src_dir}/src/parser.c -o #{out_file}"
+        ["cc", "-shared", "-fPIC", "-O2", "-I#{src_dir}/src",
+         "#{src_dir}/src/parser.c", "-o", out_file]
       end
     end
 


### PR DESCRIPTION
Fixes #18

## Changes

- Refactored `build_cmd` lambdas to return arrays instead of strings
- Updated `Open3.capture2e` to use splat operator for direct exec
- Prevents command injection and handles paths with spaces correctly

## Testing

No CLI-specific tests exist in the test suite. Manual testing recommended:
- Test building a parser from a path containing spaces
- Verify existing build functionality still works

Generated with [Claude Code](https://claude.ai/code)