### PR TITLE
chore: Use Claude Opus for all Claude workflows

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -46,5 +46,5 @@ jobs:
           # Optional: Add claude_args to customize behavior and configuration
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-          # claude_args: '--allowed-tools Bash(gh pr:*)'
+          claude_args: '--model claude-opus-4-6'
 


### PR DESCRIPTION
## Summary
- `claude.yml`（Claude Code action workflow）のモデルを `claude-opus-4-6` に変更
- `claude-code-review.yml` は #46 で既に Opus 化済み。これで全 Claude 系 Workflow が Opus に統一される

## Test plan
- [x] `claude.yml` の `claude_args` に `--model claude-opus-4-6` が設定されていることを確認
- [x] Issue や PR コメントで `@claude` を呼び出して Opus で動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)