### PR TITLE
fix: Update Faveod/tree-sitter-parsers v0.1.0 → v4.11

### DIFF
--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -157,7 +157,7 @@ jobs:
         run: |
           # 最新リリースをチェック
           LATEST=$(curl -fsSL "https://api.github.com/repos/Faveod/tree-sitter-parsers/releases/latest" | jq -r '.tag_name')
-          CURRENT="v0.1.0"  # 現在使用しているバージョン
+          CURRENT="v4.11"  # 現在使用しているバージョン
 
           echo "latest_release=$LATEST" >> $GITHUB_OUTPUT
           echo "current_release=$CURRENT" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary

- Faveod/tree-sitter-parsers v4.11 でリリースアセット形式が変更されたのに追従
  - 個別ファイル DL → tarball 展開方式に変更
  - プラットフォーム名変換追加 (`darwin-arm64` → `macos-arm64`)
- `scripts/build_parsers.sh`: Ruby parser DL を tarball 方式に
- `scripts/download_parsers.sh`: tarball 1回DL→キャッシュ→各言語抽出に全面書き換え
- `.github/workflows/sync-upstream.yml`: CURRENT バージョンを v4.11 に更新

Closes #36

## Test plan

- [x] `bundle exec rake test` 全パス (119 runs, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)