### PR TITLE
fix: Align SQL node map with actual leaf node output

### DIFF
--- a/lib/textbringer/tree_sitter/node_maps/sql.rb
+++ b/lib/textbringer/tree_sitter/node_maps/sql.rb
@@ -6,44 +6,37 @@ module Textbringer
       SQL_FEATURES = {
         keyword: %i[
           SELECT FROM WHERE JOIN LEFT RIGHT INNER OUTER FULL NATURAL CROSS
-          ON AND OR NOT IN IS NULL BETWEEN LIKE ILIKE
+          ON AND OR NOT IN IS NULL BETWEEN
           INSERT INTO VALUES UPDATE SET DELETE
           CREATE DROP ALTER TABLE INDEX VIEW SCHEMA DATABASE
-          PRIMARY_KEY FOREIGN_KEY UNIQUE CHECK CONSTRAINT REFERENCES
+          PRIMARY_KEY UNIQUE CHECK CONSTRAINT REFERENCES
           GROUP_BY ORDER_BY HAVING LIMIT OFFSET FETCH
           UNION INTERSECT EXCEPT ALL DISTINCT
           AS ASC DESC NULLS FIRST LAST
           CASE WHEN THEN ELSE END
           BEGIN COMMIT ROLLBACK TRANSACTION
-          IF EXISTS IF_EXISTS IF_NOT_EXISTS
+          IF EXISTS
           TRUE FALSE DEFAULT
           WITH RECURSIVE
           GRANT REVOKE PRIVILEGES
           RETURNS RETURN FUNCTION PROCEDURE
           FOR EACH ROW TRIGGER
-          CASCADE RESTRICT SET_NULL SET_DEFAULT
+          CASCADE RESTRICT
           VOLATILE STABLE IMMUTABLE
           DECLARE EXECUTE
+          like
         ],
         comment: %i[comment line_comment block_comment],
-        string: %i[string],
+        string: %i[content],
         number: %i[number],
-        type: %i[
-          type_cast constrained_type array_type
-          INTEGER INT SMALLINT BIGINT
-          REAL FLOAT DOUBLE DECIMAL NUMERIC
-          VARCHAR CHAR TEXT
-          BOOLEAN BOOL
-          DATE TIME TIMESTAMP TIMESTAMPTZ
-          JSON JSONB XML
-          UUID BYTEA
-          SERIAL BIGSERIAL
-        ],
-        function_name: %i[function_call],
-        variable: %i[identifier dotted_name],
-        operator: %i[binary_operator comparison_operator],
-        punctuation: %i[delimiter],
-        constant: %i[boolean_expression],
+        type: %i[],
+        function_name: %i[],
+        variable: %i[identifier],
+        operator: %i[],
+        punctuation: %i[],
+        constant: %i[],
+        builtin: %i[],
+        property: %i[],
       }.freeze
 
       SQL = SQL_FEATURES.flat_map { |face, nodes|

--- a/test/textbringer/tree_sitter/test_node_maps.rb
+++ b/test/textbringer/tree_sitter/test_node_maps.rb
@@ -501,4 +501,87 @@ class NodeMapsTest < Minitest::Test
     assert_equal :keyword, node_map[:anchor]
     assert_equal :keyword, node_map[:alias]
   end
+
+  # SQL
+  def test_sql_basic_mappings
+    node_map = Textbringer::TreeSitter::NodeMaps.for(:sql)
+
+    # キーワード
+    assert_equal :keyword, node_map[:SELECT]
+    assert_equal :keyword, node_map[:FROM]
+    assert_equal :keyword, node_map[:WHERE]
+    assert_equal :keyword, node_map[:JOIN]
+    assert_equal :keyword, node_map[:CREATE]
+    assert_equal :keyword, node_map[:TABLE]
+    assert_equal :keyword, node_map[:INSERT]
+    assert_equal :keyword, node_map[:UPDATE]
+    assert_equal :keyword, node_map[:DELETE]
+    assert_equal :keyword, node_map[:BEGIN]
+    assert_equal :keyword, node_map[:COMMIT]
+    assert_equal :keyword, node_map[:ROLLBACK]
+    assert_equal :keyword, node_map[:like]
+
+    # コメント
+    assert_equal :comment, node_map[:comment]
+    assert_equal :comment, node_map[:line_comment]
+    assert_equal :comment, node_map[:block_comment]
+
+    # 文字列（string はコンテナ、content がリーフ）
+    assert_equal :string, node_map[:content]
+    assert_nil node_map[:string]
+
+    # 数値
+    assert_equal :number, node_map[:number]
+
+    # identifier はリーフノード
+    assert_equal :variable, node_map[:identifier]
+  end
+
+  def test_sql_container_nodes_not_mapped
+    node_map = Textbringer::TreeSitter::NodeMaps.for(:sql)
+
+    # コンテナノードはマッピングされない
+    assert_nil node_map[:function_call]
+    assert_nil node_map[:binary_expression]
+    assert_nil node_map[:boolean_expression]
+    assert_nil node_map[:type_cast]
+    assert_nil node_map[:constrained_type]
+    assert_nil node_map[:array_type]
+  end
+
+  def test_sql_removed_nonexistent_keywords
+    node_map = Textbringer::TreeSitter::NodeMaps.for(:sql)
+
+    # 存在しない複合キーワードが削除されている
+    assert_nil node_map[:FOREIGN_KEY]
+    assert_nil node_map[:IF_EXISTS]
+    assert_nil node_map[:IF_NOT_EXISTS]
+    assert_nil node_map[:SET_NULL]
+    assert_nil node_map[:SET_DEFAULT]
+    assert_nil node_map[:ILIKE]
+  end
+
+  def test_sql_features_structure
+    features = Textbringer::TreeSitter::NodeMaps::SQL_FEATURES
+
+    assert features.key?(:keyword)
+    assert features.key?(:comment)
+    assert features.key?(:string)
+    assert features.key?(:number)
+    assert features.key?(:type)
+    assert features.key?(:function_name)
+    assert features.key?(:variable)
+    assert features.key?(:operator)
+
+    # keyword には like（小文字）が含まれる
+    assert features[:keyword].include?(:like)
+
+    # string は content（リーフノード）
+    assert features[:string].include?(:content)
+
+    # type, function_name, operator は空（コンテナノードのみだったため）
+    assert features[:type].empty?
+    assert features[:function_name].empty?
+    assert features[:operator].empty?
+  end
 end


### PR DESCRIPTION
## Summary

- v1.2.1 の `visit_node` リーフノード限定化により、SQL node map のコンテナノード（`string`, `function_call`, `binary_expression` 等）がマッチしなくなっていた問題を修正
- 実際の tree-sitter-sql parser 出力を調査し、node map をリーフノード型に合わせて全面修正
- SQL の node map テスト 4 件を追加

### 主な変更

| 変更前 | 変更後 | 理由 |
|---|---|---|
| `string` (string) | `content` (string) | `string` はコンテナ、`content` がリーフ |
| `function_call` (function_name) | 削除 | コンテナノード |
| `binary_operator`, `comparison_operator` (operator) | 削除 | コンテナ or 存在しない |
| `boolean_expression` (constant) | 削除 | コンテナノード |
| `INTEGER`, `VARCHAR` 等 (type) | 削除 | `identifier` として解析される |
| `type_cast` 等 (type) | 削除 | コンテナノード |
| `LIKE`, `ILIKE` (keyword) | `like`（小文字） | parser は小文字で出力 |
| `FOREIGN_KEY` 等の複合キーワード | 削除 | parser に存在しない |
| `dotted_name` (variable) | 削除 | 未確認 |

## Test plan

- [x] `bundle exec rake test` 全テストパス（125 runs, 761 assertions, 0 failures）
- [x] textbringer で `samples/sample.sql` を開いてハイライト目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)