### PR TITLE
fix: Keep mapped non-leaf nodes in highlight traversal

### DIFF
--- a/lib/textbringer/tree_sitter_adapter.rb
+++ b/lib/textbringer/tree_sitter_adapter.rb
@@ -66,7 +66,8 @@ module Textbringer
         highlight_on = {}
         highlight_off = {}
 
-        visit_node(tree.root_node) do |node, start_byte, end_byte|
+        node_map = TreeSitter::NodeMaps.for(tree_sitter_language)
+        visit_node(tree.root_node, node_map) do |node, start_byte, end_byte|
           face = node_type_to_face(node.type.to_sym)
           next unless face
 
@@ -165,13 +166,16 @@ module Textbringer
         end
       end
 
-      def visit_node(node, &block)
+      def visit_node(node, node_map = nil, &block)
         if node.child_count == 0
           block.call(node, node.start_byte, node.end_byte)
         else
+          if node_map&.key?(node.type.to_sym)
+            block.call(node, node.start_byte, node.end_byte)
+          end
           node.child_count.times do |i|
             child = node.child(i)
-            visit_node(child, &block) if child
+            visit_node(child, node_map, &block) if child
           end
         end
       end


### PR DESCRIPTION
## Summary
- `visit_node` が leaf-only になった PR #54 の変更で、node_map に登録されている非リーフノード（C の `function_declarator`、Java/C# の `method_declaration` 等）のハイライトがリグレッションしていた問題を修正
- `visit_node` に `node_map` をオプション引数で渡し、マッピングがある非リーフノードも yield するようにした
- node_map なしの場合は従来通り leaf-only（後方互換）

Closes https://github.com/yancya/textbringer-tree-sitter/pull/54#discussion_r2795484749

## Test plan
- [x] `test_visit_node_yields_mapped_non_leaf_nodes`: マッピングされた非リーフノードが yield されることを検証
- [x] `test_visit_node_without_node_map_yields_only_leaves`: node_map なしで後方互換を検証
- [x] 既存テスト全パス (127 runs, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)