### PR TITLE
feat: add ability to disable tree-sitter highlighting per mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,12 @@ CONFIG[:tree_sitter_enabled_features] = [:comment, :string, :keyword]
 # カスタム parser ディレクトリ
 CONFIG[:tree_sitter_parser_dir] = "/path/to/parsers"
 
+# 特定のモードで Tree-sitter ハイライトを無効化
+RubyMode.tree_sitter_enabled = false
+
+# 再度有効化も可能
+RubyMode.tree_sitter_enabled = true
+
 # カスタム NodeMap 読み込み
 require "~/.textbringer/tree_sitter/node_maps/mylang.rb"
 ```

--- a/README.md
+++ b/README.md
@@ -92,6 +92,18 @@ class MyMode < ProgrammingMode
 end
 ```
 
+### Disabling Tree-sitter for Specific Modes
+
+You can disable Tree-sitter highlighting for specific modes:
+
+```ruby
+# Disable for RubyMode (falls back to default Textbringer highlighting)
+RubyMode.tree_sitter_enabled = false
+
+# Re-enable when needed
+RubyMode.tree_sitter_enabled = true
+```
+
 ## Custom Languages
 
 You can add languages not included in the gem by creating a configuration file.

--- a/lib/textbringer/tree_sitter_adapter.rb
+++ b/lib/textbringer/tree_sitter_adapter.rb
@@ -16,6 +16,7 @@ module Textbringer
     module ClassMethods
       def use_tree_sitter(language)
         @tree_sitter_language = language
+        @tree_sitter_enabled = true
 
         # Use prepend to take priority over existing custom_highlight
         prepend InstanceMethods
@@ -23,6 +24,14 @@ module Textbringer
         define_method(:tree_sitter_language) do
           language
         end
+      end
+
+      def tree_sitter_enabled=(value)
+        @tree_sitter_enabled = value
+      end
+
+      def tree_sitter_enabled?
+        @tree_sitter_enabled
       end
 
       attr_reader :tree_sitter_language
@@ -212,7 +221,8 @@ module Textbringer
       alias_method :original_highlight, :highlight
 
       def highlight
-        if @buffer&.mode.respond_to?(:custom_highlight)
+        if @buffer&.mode.respond_to?(:custom_highlight) &&
+            @buffer.mode.class.tree_sitter_enabled?
           @buffer.mode.custom_highlight(self)
         else
           original_highlight

--- a/test/test_tree_sitter_adapter.rb
+++ b/test/test_tree_sitter_adapter.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+require "textbringer/tree_sitter_adapter"
+
+class TestTreeSitterAdapter < Minitest::Test
+  def setup
+    Textbringer::Face.clear_all
+    Textbringer::CONFIG.clear
+
+    # Define basic test mode
+    @test_mode_class = Class.new(Textbringer::Mode)
+    @test_mode_class.extend(Textbringer::TreeSitterAdapter::ClassMethods)
+  end
+
+  def test_use_tree_sitter_enables_by_default
+    @test_mode_class.use_tree_sitter(:ruby)
+
+    mode = @test_mode_class.new
+    assert_equal :ruby, mode.tree_sitter_language
+    assert @test_mode_class.tree_sitter_enabled?
+  end
+
+  def test_tree_sitter_enabled_setter_disables_highlight
+    @test_mode_class.use_tree_sitter(:ruby)
+    @test_mode_class.tree_sitter_enabled = false
+
+    refute @test_mode_class.tree_sitter_enabled?
+  end
+
+  def test_tree_sitter_enabled_setter_can_re_enable
+    @test_mode_class.use_tree_sitter(:ruby)
+    @test_mode_class.tree_sitter_enabled = false
+    @test_mode_class.tree_sitter_enabled = true
+
+    assert @test_mode_class.tree_sitter_enabled?
+  end
+
+  def test_window_highlight_uses_original_when_disabled
+    @test_mode_class.use_tree_sitter(:ruby)
+    @test_mode_class.tree_sitter_enabled = false
+
+    mode = @test_mode_class.new
+    buffer = Textbringer::MockBuffer.new
+    buffer.content = "def hello\nend"
+    buffer.mode = mode
+
+    window = Textbringer::Window.new(buffer)
+
+    # Window#highlight should call original_highlight when disabled
+    window.highlight
+
+    # highlight_on/off should be empty (original_highlight was called)
+    assert_empty window.instance_variable_get(:@highlight_on)
+    assert_empty window.instance_variable_get(:@highlight_off)
+  end
+end


### PR DESCRIPTION
Allow users to toggle tree-sitter highlighting on/off for specific modes using `Mode.tree_sitter_enabled = true/false`. When disabled, the mode falls back to Textbringer's default highlighting behavior.

This is useful when:
- Users want to temporarily use default highlighting for debugging
- A specific mode's tree-sitter implementation has issues
- Users prefer the original highlighting for certain file types

Changes:
- Add `tree_sitter_enabled=` class method to toggle tree-sitter
- Add `tree_sitter_enabled?` class method to check current state
- Modify Window#highlight to check enabled state before using tree-sitter
- Add comprehensive tests for enable/disable functionality
- Update documentation with usage examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)