### PR TITLE
chore: Bump Faveod/tree-sitter-parsers to v5.2

### DIFF
--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -165,7 +165,7 @@ jobs:
         run: |
           # 最新リリースをチェック
           LATEST=$(curl -fsSL "https://api.github.com/repos/Faveod/tree-sitter-parsers/releases/latest" | jq -r '.tag_name')
-          CURRENT="v5.0"  # 現在使用しているバージョン
+          CURRENT="v5.2"  # 現在使用しているバージョン
 
           echo "latest_release=$LATEST" >> $GITHUB_OUTPUT
           echo "current_release=$CURRENT" >> $GITHUB_OUTPUT

--- a/ext/textbringer_tree_sitter/extconf.rb
+++ b/ext/textbringer_tree_sitter/extconf.rb
@@ -26,7 +26,7 @@ def dylib_ext
 end
 
 PARSER_DIR = File.expand_path("~/.textbringer/parsers/#{platform}")
-FAVEOD_VERSION = "v5.0"
+FAVEOD_VERSION = "v5.2"
 CHECKSUMS_FILE = File.expand_path("~/.textbringer/parsers/checksums.json")
 
 # 自動インストールする言語

--- a/scripts/build_parsers.sh
+++ b/scripts/build_parsers.sh
@@ -39,7 +39,7 @@ faveod_platform() {
 }
 
 FAVEOD_PLATFORM=$(faveod_platform)
-FAVEOD_VERSION="v5.0"
+FAVEOD_VERSION="v5.2"
 
 echo "Building parsers for $PLATFORM..."
 

--- a/scripts/download_parsers.sh
+++ b/scripts/download_parsers.sh
@@ -51,7 +51,7 @@ else
 fi
 
 # Faveod/tree-sitter-parsers のリリースバージョン
-RELEASE_VERSION="v5.0"
+RELEASE_VERSION="v5.2"
 TARBALL_NAME="tree-sitter-parsers-${RELEASE_VERSION#v}-${FAVEOD_PLATFORM}.tar.gz"
 TARBALL_URL="https://github.com/Faveod/tree-sitter-parsers/releases/download/${RELEASE_VERSION}/${TARBALL_NAME}"
 


### PR DESCRIPTION
## Summary
- Bump pinned Faveod/tree-sitter-parsers version from `v5.0` to `v5.2` across `scripts/build_parsers.sh`, `scripts/download_parsers.sh`, `ext/textbringer_tree_sitter/extconf.rb`, and `.github/workflows/sync-upstream.yml`.

Closes #67

## Test plan
- [x] `bundle exec rake test` (138 runs, 0 failures)
- [x] Verified v5.2 tarball URL is reachable (HTTP 302 from GitHub release redirect)

🤖 Generated with [Claude Code](https://claude.com/claude-code)