### PR TITLE
feat: Automate Faveod parser bumps via PR instead of issue

### DIFF
--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -192,7 +192,8 @@ jobs:
           git add .github/workflows/sync-upstream.yml \
             ext/textbringer_tree_sitter/extconf.rb \
             scripts/build_parsers.sh \
-            scripts/download_parsers.sh
+            scripts/download_parsers.sh \
+            exe/textbringer-tree-sitter
           git commit -m "chore: Bump Faveod/tree-sitter-parsers to ${LATEST}"
           git push -f origin "$BRANCH"
 

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -176,8 +176,40 @@ jobs:
             echo "new_release=false" >> $GITHUB_OUTPUT
           fi
 
-      - name: Create Issue for new parser release
+      - name: Bump Faveod version and open PR
         if: steps.check-releases.outputs.new_release == 'true'
+        id: bump
+        continue-on-error: true
+        run: |
+          LATEST="${{ steps.check-releases.outputs.latest_release }}"
+          bash scripts/bump_faveod_version.sh "$LATEST"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          BRANCH="auto/faveod-${LATEST}"
+          git checkout -B "$BRANCH"
+          git add .github/workflows/sync-upstream.yml \
+            ext/textbringer_tree_sitter/extconf.rb \
+            scripts/build_parsers.sh \
+            scripts/download_parsers.sh
+          git commit -m "chore: Bump Faveod/tree-sitter-parsers to ${LATEST}"
+          git push -f origin "$BRANCH"
+
+          if gh pr view "$BRANCH" >/dev/null 2>&1; then
+            echo "PR already exists for $BRANCH"
+          else
+            gh pr create \
+              --title "chore: Bump Faveod/tree-sitter-parsers to ${LATEST}" \
+              --body "Automated bump from ${{ steps.check-releases.outputs.current_release }} to ${LATEST}. See https://github.com/Faveod/tree-sitter-parsers/releases/tag/${LATEST}" \
+              --head "$BRANCH" \
+              --base main
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Fall back to Issue if PR creation failed
+        if: steps.check-releases.outputs.new_release == 'true' && steps.bump.outcome == 'failure'
         uses: actions/github-script@v7
         with:
           script: |
@@ -187,7 +219,7 @@ jobs:
             const title = `[Auto] New Faveod/tree-sitter-parsers release: ${latest}`;
             const body = `## New Parser Release Available
 
-            A new release of [Faveod/tree-sitter-parsers](https://github.com/Faveod/tree-sitter-parsers) is available.
+            A new release of [Faveod/tree-sitter-parsers](https://github.com/Faveod/tree-sitter-parsers) is available, but the automated PR bump failed.
 
             - **Current version:** ${current}
             - **Latest version:** ${latest}

--- a/exe/textbringer-tree-sitter
+++ b/exe/textbringer-tree-sitter
@@ -16,7 +16,7 @@ require_relative "../lib/textbringer/tree_sitter/language_aliases"
 require_relative "../lib/textbringer/tree_sitter/platform"
 
 module TextbringerTreeSitterCLI
-  FAVEOD_VERSION = "v5.0"
+  FAVEOD_VERSION = "v5.5"
 
   # Parsers included in the Faveod tarball
   FAVEOD_PARSERS = %w[

--- a/scripts/bump_faveod_version.sh
+++ b/scripts/bump_faveod_version.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Rewrite the pinned Faveod/tree-sitter-parsers version across the 4 files
+# that carry it. See the a25be1d commit for the manual precedent.
+set -euo pipefail
+
+NEW_VERSION="${1:-}"
+
+if [[ ! "$NEW_VERSION" =~ ^v[0-9]+\.[0-9]+(\.[0-9]+)?$ ]]; then
+  echo "Error: invalid version '$NEW_VERSION' (expected format: vX.Y or vX.Y.Z)" >&2
+  exit 1
+fi
+
+FILES=(
+  ".github/workflows/sync-upstream.yml"
+  "ext/textbringer_tree_sitter/extconf.rb"
+  "scripts/build_parsers.sh"
+  "scripts/download_parsers.sh"
+)
+
+for f in "${FILES[@]}"; do
+  if [[ ! -f "$f" ]]; then
+    echo "Error: $f not found" >&2
+    exit 1
+  fi
+done
+
+sed -i.bak -E "s/CURRENT=\"v[0-9]+\.[0-9]+(\.[0-9]+)?\"/CURRENT=\"${NEW_VERSION}\"/" ".github/workflows/sync-upstream.yml"
+sed -i.bak -E "s/FAVEOD_VERSION = \"v[0-9]+\.[0-9]+(\.[0-9]+)?\"/FAVEOD_VERSION = \"${NEW_VERSION}\"/" "ext/textbringer_tree_sitter/extconf.rb"
+sed -i.bak -E "s/FAVEOD_VERSION=\"v[0-9]+\.[0-9]+(\.[0-9]+)?\"/FAVEOD_VERSION=\"${NEW_VERSION}\"/" "scripts/build_parsers.sh"
+sed -i.bak -E "s/RELEASE_VERSION=\"v[0-9]+\.[0-9]+(\.[0-9]+)?\"/RELEASE_VERSION=\"${NEW_VERSION}\"/" "scripts/download_parsers.sh"
+
+for f in "${FILES[@]}"; do
+  rm -f "${f}.bak"
+done
+
+echo "Bumped Faveod/tree-sitter-parsers version to ${NEW_VERSION} in: ${FILES[*]}"

--- a/scripts/bump_faveod_version.sh
+++ b/scripts/bump_faveod_version.sh
@@ -15,6 +15,7 @@ FILES=(
   "ext/textbringer_tree_sitter/extconf.rb"
   "scripts/build_parsers.sh"
   "scripts/download_parsers.sh"
+  "exe/textbringer-tree-sitter"
 )
 
 for f in "${FILES[@]}"; do
@@ -28,6 +29,7 @@ sed -i.bak -E "s/CURRENT=\"v[0-9]+\.[0-9]+(\.[0-9]+)?\"/CURRENT=\"${NEW_VERSION}
 sed -i.bak -E "s/FAVEOD_VERSION = \"v[0-9]+\.[0-9]+(\.[0-9]+)?\"/FAVEOD_VERSION = \"${NEW_VERSION}\"/" "ext/textbringer_tree_sitter/extconf.rb"
 sed -i.bak -E "s/FAVEOD_VERSION=\"v[0-9]+\.[0-9]+(\.[0-9]+)?\"/FAVEOD_VERSION=\"${NEW_VERSION}\"/" "scripts/build_parsers.sh"
 sed -i.bak -E "s/RELEASE_VERSION=\"v[0-9]+\.[0-9]+(\.[0-9]+)?\"/RELEASE_VERSION=\"${NEW_VERSION}\"/" "scripts/download_parsers.sh"
+sed -i.bak -E "s/FAVEOD_VERSION = \"v[0-9]+\.[0-9]+(\.[0-9]+)?\"/FAVEOD_VERSION = \"${NEW_VERSION}\"/" "exe/textbringer-tree-sitter"
 
 for f in "${FILES[@]}"; do
   rm -f "${f}.bak"

--- a/test/test_bump_faveod_version.rb
+++ b/test/test_bump_faveod_version.rb
@@ -12,6 +12,7 @@ class TestBumpFaveodVersion < Minitest::Test
     ext/textbringer_tree_sitter/extconf.rb
     scripts/build_parsers.sh
     scripts/download_parsers.sh
+    exe/textbringer-tree-sitter
   ].freeze
 
   def setup

--- a/test/test_bump_faveod_version.rb
+++ b/test/test_bump_faveod_version.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "open3"
+require "fileutils"
+require "tmpdir"
+
+class TestBumpFaveodVersion < Minitest::Test
+  SCRIPT = File.expand_path("../scripts/bump_faveod_version.sh", __dir__)
+  TARGET_FILES = %w[
+    .github/workflows/sync-upstream.yml
+    ext/textbringer_tree_sitter/extconf.rb
+    scripts/build_parsers.sh
+    scripts/download_parsers.sh
+  ].freeze
+
+  def setup
+    @dir = Dir.mktmpdir
+    TARGET_FILES.each do |relative|
+      dest = File.join(@dir, relative)
+      FileUtils.mkdir_p(File.dirname(dest))
+      FileUtils.cp(File.expand_path("../#{relative}", __dir__), dest)
+    end
+    FileUtils.cp(SCRIPT, File.join(@dir, "bump_faveod_version.sh"))
+  end
+
+  def teardown
+    FileUtils.remove_entry(@dir)
+  end
+
+  def run_bump(version)
+    Open3.capture3("bash", "bump_faveod_version.sh", version, chdir: @dir)
+  end
+
+  def test_rewrites_all_four_files
+    _out, err, status = run_bump("v5.6")
+    assert status.success?, "script should exit successfully, stderr: #{err}"
+
+    TARGET_FILES.each do |relative|
+      content = File.read(File.join(@dir, relative))
+      refute_match(/v5\.5/, content, "#{relative} should no longer reference the old version")
+      assert_match(/v5\.6/, content, "#{relative} should reference the new version")
+    end
+  end
+
+  def test_rejects_malformed_version
+    _out, err, status = run_bump("5.6")
+    refute status.success?, "script should reject a version without a leading v"
+    assert_match(/version/i, err)
+  end
+
+  def test_idempotent_when_rerun_with_same_version
+    run_bump("v5.6")
+    _out, err, status = run_bump("v5.6")
+    assert status.success?, "re-running with the same version should not fail, stderr: #{err}"
+
+    TARGET_FILES.each do |relative|
+      content = File.read(File.join(@dir, relative))
+      assert_match(/v5\.6/, content)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Adds `scripts/bump_faveod_version.sh <version>`, TDD'd against `test/test_bump_faveod_version.rb`, rewriting the pinned Faveod version across the 4 known files (a25be1d 4-file pattern)
- Wires `sync-upstream.yml` to commit + push a fixed per-version branch (`auto/faveod-<version>`) and open a PR when a new release is detected
- Falls back to the existing issue-creation flow if the bump/PR step fails
- Re-running with an unchanged version is idempotent (no-op diff)

## Test plan
- [x] `bundle exec rake test` (Ruby 3.4.8) — 141 runs, 0 failures (new script has 3 dedicated tests: rewrites all 4 files, rejects malformed version, idempotent re-run)
- [x] `ruby -ryaml -e 'YAML.load_file(...)'` — workflow YAML parses
- [ ] First real trigger (next Faveod release) will confirm the PR-creation path end-to-end in CI

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)