### PR TITLE
feat: Add core language injection engine (Injection S1)

### DIFF
--- a/lib/textbringer/tree_sitter/injection_maps.rb
+++ b/lib/textbringer/tree_sitter/injection_maps.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require_relative "language_aliases"
+
+module Textbringer
+  module TreeSitter
+    # Registry of per-language injection rules: which host node types
+    # embed another language, and how to resolve which language.
+    #
+    # Each entry is a Hash:
+    #   node_type: Symbol -- the host node type to scan for (e.g. :heredoc_body)
+    #   content:   Symbol -- the child node type whose byte range gets the
+    #                        injected highlighting (e.g. :heredoc_content)
+    #   language:  Symbol or Proc(node, source) -- the injected language,
+    #                        static or resolved dynamically per match
+    module InjectionMaps
+      class << self
+        def register(language, entries)
+          @maps ||= {}
+          @maps[LanguageAliases.to_sym(language)] = entries
+        end
+
+        def for(language)
+          (@maps ||= {})[LanguageAliases.to_sym(language)]
+        end
+
+        def clear
+          @maps = {}
+        end
+      end
+    end
+  end
+end

--- a/lib/textbringer/tree_sitter_adapter.rb
+++ b/lib/textbringer/tree_sitter_adapter.rb
@@ -2,6 +2,7 @@
 
 require_relative "tree_sitter_config"
 require_relative "tree_sitter/node_maps"
+require_relative "tree_sitter/injection_maps"
 
 module Textbringer
   module TreeSitterAdapter
@@ -82,6 +83,8 @@ module Textbringer
           ctx.highlight(base_pos + start_byte, base_pos + end_byte, face)
           highlight_count += 1
         end
+
+        highlight_injections(ctx, tree.root_node, buffer_text, base_pos)
 
         if TreeSitterAdapter.debug?
           File.open("/tmp/tree_sitter_debug.log", "a") do |f|
@@ -196,6 +199,107 @@ module Textbringer
         # Level-based control
         level = CONFIG[:tree_sitter_highlight_level] || 3
         HIGHLIGHT_LEVELS.take(level).flatten
+      end
+
+      # Highlights embedded-language regions (e.g. SQL in a Ruby heredoc).
+      # Depth is intentionally limited to 1: the injected tree is never
+      # scanned for further injections of its own.
+      def highlight_injections(ctx, root_node, source, base_pos)
+        return unless CONFIG.fetch(:tree_sitter_injection, true)
+
+        injections = TreeSitter::InjectionMaps.for(tree_sitter_language)
+        return unless injections
+
+        walk_for_injections(root_node, injections) do |host_node, entry|
+          highlight_single_injection(ctx, host_node, entry, source, base_pos)
+        end
+      end
+
+      def walk_for_injections(node, injections, &block)
+        injections.each do |entry|
+          block.call(node, entry) if node.type.to_sym == entry[:node_type]
+        end
+
+        node.child_count.times do |i|
+          child = node.child(i)
+          walk_for_injections(child, injections, &block) if child
+        end
+      end
+
+      def highlight_single_injection(ctx, host_node, entry, source, base_pos)
+        content_node = find_child_by_type(host_node, entry[:content])
+        return unless content_node
+
+        language = resolve_injection_language(entry[:language], host_node, source)
+        return unless language
+
+        parser = get_injected_parser(language)
+        return unless parser
+
+        text = source.byteslice(content_node.start_byte, content_node.end_byte - content_node.start_byte)
+        return unless text
+
+        injected_tree = parser.parse_string(nil, text)
+        return unless injected_tree
+
+        node_map = TreeSitter::NodeMaps.for(language)
+        visit_node(injected_tree.root_node, node_map) do |node, start_byte, end_byte|
+          face_name = node_type_to_face_for(language, node.type.to_sym)
+          next unless face_name
+          face = Face[face_name]
+          next unless face
+
+          ctx.highlight(
+            base_pos + content_node.start_byte + start_byte,
+            base_pos + content_node.start_byte + end_byte,
+            face
+          )
+        end
+      end
+
+      def find_child_by_type(node, type)
+        node.child_count.times do |i|
+          child = node.child(i)
+          return child if child && child.type.to_sym == type
+        end
+        nil
+      end
+
+      def resolve_injection_language(language_spec, host_node, source)
+        language_spec.respond_to?(:call) ? language_spec.call(host_node, source) : language_spec
+      end
+
+      def get_injected_parser(language)
+        @injected_parsers ||= {}
+        return @injected_parsers[language] if @injected_parsers.key?(language)
+
+        @injected_parsers[language] = load_injected_parser(language)
+      end
+
+      def load_injected_parser(language)
+        return nil unless TreeSitterConfig.parser_available?(language)
+        return nil unless defined?(::TreeSitter)
+
+        parser_path = TreeSitterConfig.parser_path(language)
+        normalized = TreeSitter::LanguageAliases.normalize(language)
+        ts_language = ::TreeSitter::Language.load(normalized, parser_path)
+
+        parser = ::TreeSitter::Parser.new
+        parser.language = ts_language
+        parser
+      rescue LoadError, ::TreeSitter::TreeSitterError, ::TreeSitter::LanguageLoadError
+        nil
+      end
+
+      def node_type_to_face_for(language, node_type)
+        node_map = TreeSitter::NodeMaps.for(language)
+        return nil unless node_map
+
+        face = node_map[node_type]
+        return nil unless face
+        return nil unless enabled_faces.include?(face)
+
+        face
       end
 
     end

--- a/test/test_tree_sitter_injection.rb
+++ b/test/test_tree_sitter_injection.rb
@@ -1,0 +1,278 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+require "textbringer/tree_sitter_adapter"
+require "textbringer/tree_sitter/injection_maps"
+
+# Minimal duck-typed Tree-sitter node double: no real parser needed to
+# exercise the injection engine's tree-walking and offset math.
+class FakeNode
+  attr_reader :type, :start_byte, :end_byte, :children
+
+  def initialize(type, start_byte, end_byte, children = [])
+    @type = type
+    @start_byte = start_byte
+    @end_byte = end_byte
+    @children = children
+  end
+
+  def child_count
+    children.size
+  end
+
+  def child(i)
+    children[i]
+  end
+end
+
+FakeTree = Struct.new(:root_node)
+
+class FakeParser
+  def initialize(tree)
+    @tree = tree
+  end
+
+  def parse_string(_old_tree, _text)
+    @tree
+  end
+end
+
+class TestTreeSitterInjection < Minitest::Test
+  def setup
+    Textbringer::Face.clear_all
+    Textbringer::CONFIG.clear
+    Textbringer::TreeSitter::InjectionMaps.clear
+    Textbringer::TreeSitter::NodeMaps.clear_custom_maps
+
+    Textbringer::TreeSitterConfig.define_default_faces
+
+    @test_mode_class = Class.new(Textbringer::Mode)
+    @test_mode_class.extend(Textbringer::TreeSitterAdapter::ClassMethods)
+    @test_mode_class.use_tree_sitter(:ruby)
+
+    @mode = @test_mode_class.new
+    @buffer = Textbringer::MockBuffer.new
+    @buffer.mode = @mode
+  end
+
+  def content_node(source_offset, text)
+    FakeNode.new(:heredoc_content, source_offset, source_offset + text.bytesize)
+  end
+
+  def host_root(content)
+    FakeNode.new(:program, 0, 100, [
+      FakeNode.new(:heredoc_body, content.start_byte, content.end_byte, [content])
+    ])
+  end
+
+  def ctx_for(source)
+    Textbringer::HighlightContext.new(
+      buffer: @buffer,
+      highlight_start: 0,
+      highlight_end: source.bytesize,
+      highlight_on: {},
+      highlight_off: {}
+    )
+  end
+
+  def sql_injection_map(language: :sql)
+    [{ node_type: :heredoc_body, content: :heredoc_content, language: language }]
+  end
+
+  def test_injects_and_highlights_content_with_offset
+    Textbringer::TreeSitter::InjectionMaps.register(:ruby, sql_injection_map)
+    Textbringer::TreeSitter::NodeMaps.register(:sql, { select_kw: :keyword })
+
+    inner_text = "select_kw"
+    offset = 10
+    content = content_node(offset, inner_text)
+    root = host_root(content)
+
+    inner_root = FakeNode.new(:select_kw, 0, inner_text.bytesize)
+    fake_tree = FakeTree.new(inner_root)
+    @mode.define_singleton_method(:get_injected_parser) { |_lang| FakeParser.new(fake_tree) }
+
+    source = " " * 100
+    ctx = ctx_for(source)
+    @mode.send(:highlight_injections, ctx, root, source, 0)
+
+    assert_equal Textbringer::Face[:keyword], ctx.highlight_on[offset]
+    assert_equal true, ctx.highlight_off[offset + inner_text.bytesize]
+  end
+
+  def test_offset_accounts_for_base_pos
+    Textbringer::TreeSitter::InjectionMaps.register(:ruby, sql_injection_map)
+    Textbringer::TreeSitter::NodeMaps.register(:sql, { select_kw: :keyword })
+
+    inner_text = "select_kw"
+    content = content_node(10, inner_text)
+    root = host_root(content)
+    inner_root = FakeNode.new(:select_kw, 0, inner_text.bytesize)
+    fake_tree = FakeTree.new(inner_root)
+    @mode.define_singleton_method(:get_injected_parser) { |_lang| FakeParser.new(fake_tree) }
+
+    source = " " * 100
+    ctx = ctx_for(source)
+    base_pos = 1000
+    @mode.send(:highlight_injections, ctx, root, source, base_pos)
+
+    assert_equal Textbringer::Face[:keyword], ctx.highlight_on[base_pos + 10]
+  end
+
+  def test_resolves_language_via_proc
+    resolver = ->(_node, _source) { :sql }
+    Textbringer::TreeSitter::InjectionMaps.register(:ruby, sql_injection_map(language: resolver))
+    Textbringer::TreeSitter::NodeMaps.register(:sql, { select_kw: :keyword })
+
+    inner_text = "select_kw"
+    content = content_node(5, inner_text)
+    root = host_root(content)
+    inner_root = FakeNode.new(:select_kw, 0, inner_text.bytesize)
+    fake_tree = FakeTree.new(inner_root)
+    @mode.define_singleton_method(:get_injected_parser) { |lang| lang == :sql ? FakeParser.new(fake_tree) : nil }
+
+    source = " " * 100
+    ctx = ctx_for(source)
+    @mode.send(:highlight_injections, ctx, root, source, 0)
+
+    assert_equal Textbringer::Face[:keyword], ctx.highlight_on[5]
+  end
+
+  def test_skips_silently_when_no_injection_map_registered
+    content = content_node(5, "select_kw")
+    root = host_root(content)
+
+    source = " " * 100
+    ctx = ctx_for(source)
+    @mode.send(:highlight_injections, ctx, root, source, 0)
+
+    assert_empty ctx.highlight_on
+  end
+
+  def test_skips_silently_when_injected_parser_unavailable
+    Textbringer::TreeSitter::InjectionMaps.register(:ruby, sql_injection_map)
+    content = content_node(5, "select_kw")
+    root = host_root(content)
+    @mode.define_singleton_method(:get_injected_parser) { |_lang| nil }
+
+    source = " " * 100
+    ctx = ctx_for(source)
+    @mode.send(:highlight_injections, ctx, root, source, 0)
+
+    assert_empty ctx.highlight_on
+  end
+
+  def test_skips_silently_when_content_node_missing
+    Textbringer::TreeSitter::InjectionMaps.register(:ruby, sql_injection_map)
+    # heredoc_body with no matching :heredoc_content child
+    root = FakeNode.new(:program, 0, 100, [
+      FakeNode.new(:heredoc_body, 10, 20, [FakeNode.new(:heredoc_end, 18, 20)])
+    ])
+    @mode.define_singleton_method(:get_injected_parser) { |_lang| raise "should not be called" }
+
+    source = " " * 100
+    ctx = ctx_for(source)
+    @mode.send(:highlight_injections, ctx, root, source, 0)
+
+    assert_empty ctx.highlight_on
+  end
+
+  def test_disabled_via_config_flag
+    Textbringer::CONFIG[:tree_sitter_injection] = false
+    Textbringer::TreeSitter::InjectionMaps.register(:ruby, sql_injection_map)
+    Textbringer::TreeSitter::NodeMaps.register(:sql, { select_kw: :keyword })
+
+    inner_text = "select_kw"
+    content = content_node(5, inner_text)
+    root = host_root(content)
+    inner_root = FakeNode.new(:select_kw, 0, inner_text.bytesize)
+    fake_tree = FakeTree.new(inner_root)
+    @mode.define_singleton_method(:get_injected_parser) { |_lang| FakeParser.new(fake_tree) }
+
+    source = " " * 100
+    ctx = ctx_for(source)
+    @mode.send(:highlight_injections, ctx, root, source, 0)
+
+    assert_empty ctx.highlight_on
+  end
+
+  def test_depth_limit_does_not_recurse_into_injected_tree
+    # Register an injection map for :sql too (as if SQL could embed something else).
+    # The engine must not attempt to apply it to the already-injected tree (depth 1).
+    Textbringer::TreeSitter::InjectionMaps.register(:ruby, sql_injection_map)
+    Textbringer::TreeSitter::InjectionMaps.register(:sql, [{ node_type: :select_kw, content: :inner, language: :json }])
+    Textbringer::TreeSitter::NodeMaps.register(:sql, { select_kw: :keyword })
+
+    inner_text = "select_kw"
+    content = content_node(5, inner_text)
+    root = host_root(content)
+    inner_root = FakeNode.new(:select_kw, 0, inner_text.bytesize)
+    fake_tree = FakeTree.new(inner_root)
+
+    calls = []
+    @mode.define_singleton_method(:get_injected_parser) { |lang|
+      calls << lang
+      lang == :sql ? FakeParser.new(fake_tree) : (raise "should not recurse into #{lang}")
+    }
+
+    source = " " * 100
+    ctx = ctx_for(source)
+    @mode.send(:highlight_injections, ctx, root, source, 0)
+
+    assert_equal [:sql], calls
+  end
+
+  def test_byte_offsets_correct_with_multibyte_prefix
+    Textbringer::TreeSitter::InjectionMaps.register(:ruby, sql_injection_map)
+    Textbringer::TreeSitter::NodeMaps.register(:sql, { select_kw: :keyword })
+
+    # "あ" is 3 bytes in UTF-8; the injected content starts right after it.
+    prefix = "query = # あ\n<<~SQL\n"
+    inner_text = "select_kw"
+    offset = prefix.bytesize
+    content = content_node(offset, inner_text)
+    root = host_root(content)
+
+    inner_root = FakeNode.new(:select_kw, 0, inner_text.bytesize)
+    fake_tree = FakeTree.new(inner_root)
+    @mode.define_singleton_method(:get_injected_parser) { |_lang| FakeParser.new(fake_tree) }
+
+    source = prefix + inner_text + "\nSQL\n"
+    ctx = ctx_for(source)
+    @mode.send(:highlight_injections, ctx, root, source, 0)
+
+    assert_equal Textbringer::Face[:keyword], ctx.highlight_on[offset]
+    assert_equal true, ctx.highlight_off[offset + inner_text.bytesize]
+  end
+
+  def test_nested_same_type_host_nodes_both_inject_last_write_wins
+    # walk_for_injections is a plain top-down walk with no skip-content
+    # behavior: nesting two hosts of the same node_type (unusual, but not
+    # prevented) makes both fire. The outer is highlighted first, then the
+    # walk descends and the inner (narrower) overwrites it on the shared
+    # range, since ctx.highlight is last-write-wins. This documents that
+    # behavior rather than crashing or silently dropping one.
+    Textbringer::TreeSitter::InjectionMaps.register(:ruby, sql_injection_map)
+    Textbringer::TreeSitter::NodeMaps.register(:sql, { select_kw: :keyword, from_kw: :type })
+
+    outer_content = content_node(0, "outer_select_kw")
+    inner_content = content_node(6, "select_kw")
+    inner_host = FakeNode.new(:heredoc_body, inner_content.start_byte, inner_content.end_byte, [inner_content])
+    outer_host = FakeNode.new(:heredoc_body, outer_content.start_byte, outer_content.end_byte,
+                               [outer_content, inner_host])
+    root = FakeNode.new(:program, 0, 100, [outer_host])
+
+    outer_tree = FakeTree.new(FakeNode.new(:from_kw, 0, "outer_select_kw".bytesize))
+    inner_tree = FakeTree.new(FakeNode.new(:select_kw, 0, "select_kw".bytesize))
+    trees = [outer_tree, inner_tree]
+    @mode.define_singleton_method(:get_injected_parser) { |_lang| FakeParser.new(trees.shift) }
+
+    source = " " * 100
+    ctx = ctx_for(source)
+    @mode.send(:highlight_injections, ctx, root, source, 0)
+
+    # Both hosts fired (outer's :from_kw face, then inner's :select_kw face
+    # overwrote the overlapping start offset since it's processed second).
+    assert_equal Textbringer::Face[:keyword], ctx.highlight_on[inner_content.start_byte]
+  end
+end

--- a/test/textbringer/tree_sitter/test_injection_maps.rb
+++ b/test/textbringer/tree_sitter/test_injection_maps.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "textbringer/tree_sitter/injection_maps"
+
+class InjectionMapsTest < Minitest::Test
+  def setup
+    Textbringer::TreeSitter::InjectionMaps.clear
+  end
+
+  def teardown
+    Textbringer::TreeSitter::InjectionMaps.clear
+  end
+
+  def test_for_returns_nil_when_nothing_registered
+    assert_nil Textbringer::TreeSitter::InjectionMaps.for(:ruby)
+  end
+
+  def test_register_and_for_roundtrip
+    entries = [{ node_type: :heredoc_body, content: :heredoc_content, language: :sql }]
+    Textbringer::TreeSitter::InjectionMaps.register(:ruby, entries)
+
+    assert_equal entries, Textbringer::TreeSitter::InjectionMaps.for(:ruby)
+  end
+
+  def test_register_normalizes_language_aliases
+    entries = [{ node_type: :x, content: :y, language: :html }]
+    Textbringer::TreeSitter::InjectionMaps.register(:"c-sharp", entries)
+
+    assert_equal entries, Textbringer::TreeSitter::InjectionMaps.for(:csharp)
+    assert_equal entries, Textbringer::TreeSitter::InjectionMaps.for(:"c-sharp")
+  end
+
+  def test_for_accepts_proc_language_resolver
+    resolver = ->(node, source) { :sql }
+    entries = [{ node_type: :heredoc_body, content: :heredoc_content, language: resolver }]
+    Textbringer::TreeSitter::InjectionMaps.register(:ruby, entries)
+
+    got = Textbringer::TreeSitter::InjectionMaps.for(:ruby)
+    assert_equal :sql, got.first[:language].call(nil, nil)
+  end
+
+  def test_clear_removes_all_registrations
+    Textbringer::TreeSitter::InjectionMaps.register(:ruby, [{ node_type: :a, content: :b, language: :sql }])
+    Textbringer::TreeSitter::InjectionMaps.clear
+
+    assert_nil Textbringer::TreeSitter::InjectionMaps.for(:ruby)
+  end
+end


### PR DESCRIPTION
## Summary
- Adds `InjectionMaps` registry (mirrors `NodeMaps`) and a `highlight_injections` engine in the adapter: after the primary highlight pass, scans the host tree for registered node types, finds the content child, resolves the injected language (Symbol or dynamic Proc), loads a secondary parser, parses the content byteslice, and highlights it via the existing `visit_node` walker with the correct offset
- `CONFIG[:tree_sitter_injection]` (default true) disables the whole pass
- Depth capped at 1 by design — injected trees are never themselves scanned for injections
- Foundation for #79 (Ruby heredoc → SQL/HTML/JSON) and #80 (ERB) — see #77 for the full design, validated earlier this session against a live parse of `tree-sitter-ruby`'s heredoc structure

## Test plan
- [x] `bundle exec rake test` — 153 runs, 0 failures
- [x] TDD'd with duck-typed `FakeNode`/`FakeTree`/`FakeParser` doubles (no real parser binary dependency, since CI has no guaranteed parser-install step)
- [x] Manual smoke test against a real installed `ruby_tree_sitter` parser: `query = <<~SQL\n  SELECT * FROM users\nSQL` correctly highlights `SELECT`/`FROM` as keywords inside the heredoc
- [x] Reviewed by codex-advisor/gemini-advisor/grok-advisor across two rounds (150+ line diff gate) — see commit message for findings applied (nil-caching fix for `@injected_parsers`, a documented nested-host-node test, verified `byteslice` never raises for the guarded cases)

## Known, accepted limitations (tracked separately)
- `find_child_by_type` only checks direct children (matches the heredoc_body/heredoc_content shape this targets)
- No incremental re-parse caching for injected content yet (#81)

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)