### PR TITLE
feat: Add Ruby heredoc language injection (Injection S2)

### DIFF
--- a/lib/textbringer/tree_sitter/injection_maps.rb
+++ b/lib/textbringer/tree_sitter/injection_maps.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "language_aliases"
+require_relative "injection_maps/ruby"
 
 module Textbringer
   module TreeSitter
@@ -13,19 +14,43 @@ module Textbringer
     #                        injected highlighting (e.g. :heredoc_content)
     #   language:  Symbol or Proc(node, source) -- the injected language,
     #                        static or resolved dynamically per match
+    #
+    # Two tiers, mirroring NodeMaps: gem-bundled defaults (constants under
+    # injection_maps/, e.g. injection_maps/ruby.rb's InjectionMaps::RUBY) and
+    # user-registered custom entries (added via `register`, wiped by `clear`).
+    # `for` returns both combined; `clear` only affects the custom tier, so
+    # bundled defaults survive it.
     module InjectionMaps
       class << self
         def register(language, entries)
-          @maps ||= {}
-          @maps[LanguageAliases.to_sym(language)] = entries
+          @custom_maps ||= {}
+          @custom_maps[LanguageAliases.to_sym(language)] = entries
         end
 
         def for(language)
-          (@maps ||= {})[LanguageAliases.to_sym(language)]
+          normalized = LanguageAliases.to_sym(language)
+          combined = default_entries(normalized) + custom_entries(normalized)
+          combined.empty? ? nil : combined
         end
 
         def clear
-          @maps = {}
+          @custom_maps = {}
+        end
+
+        private
+
+        def default_maps
+          {
+            ruby: RUBY
+          }
+        end
+
+        def default_entries(normalized)
+          default_maps[normalized] || []
+        end
+
+        def custom_entries(normalized)
+          (@custom_maps ||= {})[normalized] || []
         end
       end
     end

--- a/lib/textbringer/tree_sitter/injection_maps/ruby.rb
+++ b/lib/textbringer/tree_sitter/injection_maps/ruby.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Textbringer
+  module TreeSitter
+    module InjectionMaps
+      # Resolves the injected language from a Ruby heredoc's closing tag.
+      # tree-sitter-ruby's heredoc_body always carries a heredoc_end child
+      # whose text is the bare tag (e.g. "SQL"), regardless of whether the
+      # opening delimiter was <<~SQL, <<SQL, or the quoted <<~'SQL' form --
+      # verified against a live parse of all three (quoting only affects
+      # heredoc_content escape/interpolation processing, not the tag itself).
+      #
+      # No parser-availability check happens here: an unrecognized or
+      # unsupported tag still resolves to a Symbol, and the highlighting
+      # engine's get_injected_parser (see tree_sitter_adapter.rb) already
+      # skips gracefully when no matching parser is installed.
+      RUBY_HEREDOC_LANGUAGE_RESOLVER = lambda { |host_node, source|
+        tag_node = nil
+        host_node.child_count.times do |i|
+          child = host_node.child(i)
+          tag_node = child if child && child.type.to_sym == :heredoc_end
+        end
+        next nil unless tag_node
+
+        tag_text = source.byteslice(tag_node.start_byte, tag_node.end_byte - tag_node.start_byte)
+        next nil if tag_text.nil? || tag_text.empty?
+
+        LanguageAliases.to_sym(tag_text.downcase)
+      }
+
+      RUBY = [
+        {
+          node_type: :heredoc_body,
+          content: :heredoc_content,
+          language: RUBY_HEREDOC_LANGUAGE_RESOLVER
+        }
+      ].freeze
+    end
+  end
+end

--- a/test/textbringer/tree_sitter/test_injection_maps.rb
+++ b/test/textbringer/tree_sitter/test_injection_maps.rb
@@ -13,14 +13,14 @@ class InjectionMapsTest < Minitest::Test
   end
 
   def test_for_returns_nil_when_nothing_registered
-    assert_nil Textbringer::TreeSitter::InjectionMaps.for(:ruby)
+    assert_nil Textbringer::TreeSitter::InjectionMaps.for(:custom_lang)
   end
 
   def test_register_and_for_roundtrip
     entries = [{ node_type: :heredoc_body, content: :heredoc_content, language: :sql }]
-    Textbringer::TreeSitter::InjectionMaps.register(:ruby, entries)
+    Textbringer::TreeSitter::InjectionMaps.register(:custom_lang, entries)
 
-    assert_equal entries, Textbringer::TreeSitter::InjectionMaps.for(:ruby)
+    assert_equal entries, Textbringer::TreeSitter::InjectionMaps.for(:custom_lang)
   end
 
   def test_register_normalizes_language_aliases
@@ -34,16 +34,30 @@ class InjectionMapsTest < Minitest::Test
   def test_for_accepts_proc_language_resolver
     resolver = ->(node, source) { :sql }
     entries = [{ node_type: :heredoc_body, content: :heredoc_content, language: resolver }]
-    Textbringer::TreeSitter::InjectionMaps.register(:ruby, entries)
+    Textbringer::TreeSitter::InjectionMaps.register(:custom_lang, entries)
 
-    got = Textbringer::TreeSitter::InjectionMaps.for(:ruby)
+    got = Textbringer::TreeSitter::InjectionMaps.for(:custom_lang)
     assert_equal :sql, got.first[:language].call(nil, nil)
   end
 
-  def test_clear_removes_all_registrations
-    Textbringer::TreeSitter::InjectionMaps.register(:ruby, [{ node_type: :a, content: :b, language: :sql }])
+  def test_clear_removes_custom_registrations
+    Textbringer::TreeSitter::InjectionMaps.register(:custom_lang, [{ node_type: :a, content: :b, language: :sql }])
     Textbringer::TreeSitter::InjectionMaps.clear
 
-    assert_nil Textbringer::TreeSitter::InjectionMaps.for(:ruby)
+    assert_nil Textbringer::TreeSitter::InjectionMaps.for(:custom_lang)
+  end
+
+  def test_clear_does_not_remove_bundled_defaults
+    Textbringer::TreeSitter::InjectionMaps.clear
+
+    refute_nil Textbringer::TreeSitter::InjectionMaps.for(:ruby)
+  end
+
+  def test_custom_registration_is_combined_with_bundled_defaults
+    Textbringer::TreeSitter::InjectionMaps.register(:ruby, [{ node_type: :c, content: :d, language: :html }])
+
+    result = Textbringer::TreeSitter::InjectionMaps.for(:ruby)
+    assert_includes result.map { |e| e[:node_type] }, :heredoc_body
+    assert_includes result.map { |e| e[:node_type] }, :c
   end
 end

--- a/test/textbringer/tree_sitter/test_injection_maps_ruby.rb
+++ b/test/textbringer/tree_sitter/test_injection_maps_ruby.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "textbringer/tree_sitter/injection_maps"
+
+# Minimal duck-typed node double matching the tree-sitter-ruby heredoc shape:
+#   heredoc_body
+#     heredoc_content
+#     heredoc_end   <- carries the plain tag text, e.g. "SQL" (never quoted,
+#                       regardless of whether heredoc_beginning was <<~SQL,
+#                       <<~'SQL', or <<SQL -- verified against a live parse)
+FakeHeredocNode = Struct.new(:type, :start_byte, :end_byte)
+FakeHeredocBody = Struct.new(:children) do
+  def type
+    :heredoc_body
+  end
+
+  def child_count
+    children.size
+  end
+
+  def child(i)
+    children[i]
+  end
+end
+
+class InjectionMapsRubyTest < Minitest::Test
+  # No InjectionMaps.clear here: :ruby's heredoc injection is a bundled
+  # default (register_default), which clear intentionally leaves alone.
+
+  def entry
+    Textbringer::TreeSitter::InjectionMaps.for(:ruby).find { |e| e[:node_type] == :heredoc_body }
+  end
+
+  def host_node_and_source(tag_text)
+    prefix = "x" * 100
+    source = prefix + tag_text
+    node = FakeHeredocBody.new([
+      FakeHeredocNode.new(:heredoc_content, 0, prefix.bytesize),
+      FakeHeredocNode.new(:heredoc_end, prefix.bytesize, source.bytesize)
+    ])
+    [node, source]
+  end
+
+  def resolve(tag_text)
+    node, source = host_node_and_source(tag_text)
+    entry[:language].call(node, source)
+  end
+
+  def test_registers_ruby_heredoc_injection
+    refute_nil Textbringer::TreeSitter::InjectionMaps.for(:ruby)
+    assert_equal :heredoc_body, entry[:node_type]
+    assert_equal :heredoc_content, entry[:content]
+  end
+
+  def test_resolves_sql_tag
+    assert_equal :sql, resolve("SQL")
+  end
+
+  def test_resolves_html_tag
+    assert_equal :html, resolve("HTML")
+  end
+
+  def test_resolves_json_tag
+    assert_equal :json, resolve("JSON")
+  end
+
+  def test_resolves_lowercase_tag
+    assert_equal :sql, resolve("sql")
+  end
+
+  def test_resolves_unrecognized_tags_too
+    # No availability check here: an unrecognized tag like EOS still
+    # resolves to a symbol. Whether it actually highlights depends on
+    # whether a parser for that language is installed -- that check
+    # already happens in the engine's get_injected_parser (see S1/#78),
+    # so this map doesn't need to duplicate it.
+    assert_equal :eos, resolve("EOS")
+  end
+
+  def test_missing_heredoc_end_child_returns_nil
+    body = FakeHeredocBody.new([FakeHeredocNode.new(:heredoc_content, 0, 5)])
+    assert_nil entry[:language].call(body, "x" * 200)
+  end
+end


### PR DESCRIPTION
## Summary
- Wires the S1 core engine (#78, PR #86 — **this PR targets that branch since #86 isn't merged yet**) to Ruby heredocs: `<<~SQL`, `<<~HTML`, `<<~JSON` etc. resolve automatically from the closing tag
- `injection_maps/ruby.rb`: reads the heredoc's closing tag (`heredoc_end` child text) and resolves it via `LanguageAliases.to_sym` — no availability check needed here since the engine's `get_injected_parser` already skips gracefully for unrecognized tags
- Refactored `injection_maps.rb` into a two-tier registry (bundled defaults + user `register`), mirroring `NodeMaps` — fixes a circular-require bug caught while writing this (see commit message)

## Test plan
- [x] `bundle exec rake test` — 162 runs, 0 failures
- [x] Manual: a buffer with adjacent `<<~SQL` and `<<~HTML` heredocs correctly highlights SQL keywords and HTML tags in each, independently, against a real installed parser
- [x] Reviewed by codex-advisor/gemini-advisor/grok-advisor (150+ line diff gate) — no code-level bugs found; two theoretical concerns investigated and confirmed not to require changes (see commit message: a renderer face-nesting question resolved by tracing `window.rb` + an empirical render trace, and a known S1 limitation re: interpolated heredocs)

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)