### PR TITLE
feat: Add ERB support via embedded-template parser (Injection S3)

### DIFF
--- a/lib/textbringer/tree_sitter/injection_maps.rb
+++ b/lib/textbringer/tree_sitter/injection_maps.rb
@@ -2,6 +2,7 @@
 
 require_relative "language_aliases"
 require_relative "injection_maps/ruby"
+require_relative "injection_maps/embedded_template"
 
 module Textbringer
   module TreeSitter
@@ -41,7 +42,8 @@ module Textbringer
 
         def default_maps
           {
-            ruby: RUBY
+            ruby: RUBY,
+            :"embedded-template" => EMBEDDED_TEMPLATE
           }
         end
 

--- a/lib/textbringer/tree_sitter/injection_maps/embedded_template.rb
+++ b/lib/textbringer/tree_sitter/injection_maps/embedded_template.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Textbringer
+  module TreeSitter
+    module InjectionMaps
+      # ERB (Faveod's embedded-template grammar): Ruby code inside <% %> /
+      # <%= %>, HTML everywhere else. Unlike the Ruby heredoc map, these are
+      # static -- ERB's own grammar already separates code from content, no
+      # per-match language resolution needed.
+      #
+      # :content entries use content == node_type ("self-injection"): a
+      # `content` node IS the HTML text leaf, not a wrapper around one.
+      EMBEDDED_TEMPLATE = [
+        { node_type: :directive, content: :code, language: :ruby },
+        { node_type: :output_directive, content: :code, language: :ruby },
+        { node_type: :content, content: :content, language: :html }
+      ].freeze
+    end
+  end
+end

--- a/lib/textbringer/tree_sitter/node_maps.rb
+++ b/lib/textbringer/tree_sitter/node_maps.rb
@@ -9,6 +9,7 @@ require_relative "node_maps/csharp"
 require_relative "node_maps/cobol"
 require_relative "node_maps/crystal"
 require_relative "node_maps/elixir"
+require_relative "node_maps/embedded_template"
 require_relative "node_maps/groovy"
 require_relative "node_maps/haml"
 require_relative "node_maps/html"
@@ -71,6 +72,7 @@ module Textbringer
             cobol: COBOL,
             crystal: CRYSTAL,
             elixir: ELIXIR,
+            :"embedded-template" => EMBEDDED_TEMPLATE,
             groovy: GROOVY,
             haml: HAML,
             html: HTML,

--- a/lib/textbringer/tree_sitter/node_maps/embedded_template.rb
+++ b/lib/textbringer/tree_sitter/node_maps/embedded_template.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Textbringer
+  module TreeSitter
+    module NodeMaps
+      # ERB/embedded-template delimiters. `code` and `content` are
+      # intentionally left unmapped here -- they're highlighted via
+      # language injection instead (see injection_maps/embedded_template.rb).
+      EMBEDDED_TEMPLATE_FEATURES = {
+        comment: %i[comment comment_directive],
+        keyword: %i[
+          <%
+          <%=
+          <%==
+          <%_
+          <%|
+          <%-
+          <%%
+          <%#
+          %>
+          -%>
+          _%>
+          %%>
+          =%>
+        ]
+      }.freeze
+
+      EMBEDDED_TEMPLATE = EMBEDDED_TEMPLATE_FEATURES.flat_map { |face, nodes|
+        nodes.map { |node| [node, face] }
+      }.to_h.freeze
+    end
+  end
+end

--- a/lib/textbringer/tree_sitter_adapter.rb
+++ b/lib/textbringer/tree_sitter_adapter.rb
@@ -144,10 +144,13 @@ module Textbringer
           return nil unless defined?(::TreeSitter)
 
           parser_path = TreeSitterConfig.parser_path(tree_sitter_language)
-          # Normalize language name for TreeSitter::Language.load
+          # Normalize for the file path (may keep hyphens, e.g. "embedded-template"),
+          # then replace hyphens with underscores for the exported C symbol name
+          # (tree_sitter_<name>) -- mirrors ruby_tree_sitter's own TreeSitter.language
+          # convenience method, which does the same before calling Language.load.
           normalized = TreeSitter::LanguageAliases.normalize(tree_sitter_language)
           language = ::TreeSitter::Language.load(
-            normalized,
+            normalized.tr("-", "_"),
             parser_path
           )
 
@@ -227,7 +230,14 @@ module Textbringer
       end
 
       def highlight_single_injection(ctx, host_node, entry, source, base_pos)
-        content_node = find_child_by_type(host_node, entry[:content])
+        # entry[:content] == entry[:node_type] means "inject this node
+        # itself" (e.g. ERB's :content nodes, which are plain text leaves,
+        # not a wrapper around a separate content child).
+        content_node = if entry[:content] == entry[:node_type]
+                          host_node
+                        else
+                          find_child_by_type(host_node, entry[:content])
+                        end
         return unless content_node
 
         language = resolve_injection_language(entry[:language], host_node, source)
@@ -282,7 +292,7 @@ module Textbringer
 
         parser_path = TreeSitterConfig.parser_path(language)
         normalized = TreeSitter::LanguageAliases.normalize(language)
-        ts_language = ::TreeSitter::Language.load(normalized, parser_path)
+        ts_language = ::TreeSitter::Language.load(normalized.tr("-", "_"), parser_path)
 
         parser = ::TreeSitter::Parser.new
         parser.language = ts_language

--- a/lib/textbringer_plugin.rb
+++ b/lib/textbringer_plugin.rb
@@ -63,6 +63,7 @@ MODE_LANGUAGE_MAP = {
   "GroovyMode" => :groovy,
   "HamlMode" => :haml,
   "PascalMode" => :pascal,
+  "ERBMode" => :"embedded-template",
 }.freeze
 
 # Language -> file pattern (for automatic Mode generation)
@@ -93,6 +94,7 @@ LANGUAGE_FILE_PATTERNS = {
   groovy: /\.(groovy|gvy|gy|gradle)$/i,
   haml: /\.haml$/i,
   pascal: /\.(pas|pp|p|inc)$/i,
+  :"embedded-template" => /\.erb$/i,
 }.freeze
 
 # Auto-generate Mode for languages that have parser + node_map but no existing Mode

--- a/test/test_tree_sitter_injection.rb
+++ b/test/test_tree_sitter_injection.rb
@@ -275,4 +275,40 @@ class TestTreeSitterInjection < Minitest::Test
     # overwrote the overlapping start offset since it's processed second).
     assert_equal Textbringer::Face[:keyword], ctx.highlight_on[inner_content.start_byte]
   end
+
+  def test_self_injection_when_content_type_equals_node_type
+    # ERB's "content" nodes (plain HTML/text between directives) ARE the
+    # leaf to inject, not a wrapper around one -- entry[:content] equal to
+    # entry[:node_type] means "inject this node itself".
+    Textbringer::TreeSitter::InjectionMaps.register(:embedded_template,
+      [{ node_type: :content, content: :content, language: :html }])
+    Textbringer::TreeSitter::NodeMaps.register(:html, { tag_name: :keyword })
+
+    erb_mode_class = Class.new(Textbringer::Mode)
+    erb_mode_class.extend(Textbringer::TreeSitterAdapter::ClassMethods)
+    erb_mode_class.use_tree_sitter(:embedded_template)
+    erb_mode = erb_mode_class.new
+    erb_buffer = Textbringer::MockBuffer.new
+    erb_buffer.mode = erb_mode
+
+    host = FakeNode.new(:content, 5, 15)
+    root = FakeNode.new(:template, 0, 100, [host])
+
+    inner_root = FakeNode.new(:tag_name, 0, 10)
+    fake_tree = FakeTree.new(inner_root)
+    erb_mode.define_singleton_method(:get_injected_parser) { |_lang| FakeParser.new(fake_tree) }
+
+    source = " " * 100
+    ctx = Textbringer::HighlightContext.new(
+      buffer: erb_buffer,
+      highlight_start: 0,
+      highlight_end: source.bytesize,
+      highlight_on: {},
+      highlight_off: {}
+    )
+    erb_mode.send(:highlight_injections, ctx, root, source, 0)
+
+    assert_equal Textbringer::Face[:keyword], ctx.highlight_on[5]
+    assert_equal true, ctx.highlight_off[15]
+  end
 end

--- a/test/textbringer/test_plugin_integration.rb
+++ b/test/textbringer/test_plugin_integration.rb
@@ -31,6 +31,31 @@ class PluginIntegrationTest < Minitest::Test
     assert_equal :markdown, mode_language_map["MarkdownMode"]
   end
 
+  def test_mode_language_map_includes_erb
+    mode_language_map = { "ERBMode" => :"embedded-template" }
+    assert_equal :"embedded-template", mode_language_map["ERBMode"]
+  end
+
+  def test_erb_mode_gets_tree_sitter_enabled
+    skip "embedded-template parser not installed" unless parser_available?(:"embedded-template")
+
+    erb_mode = Class.new(Textbringer::Mode)
+    Textbringer.const_set(:TestERBMode, erb_mode)
+
+    Textbringer::TreeSitter::NodeMaps.register(:"embedded-template", { "<%": :keyword })
+
+    language = :"embedded-template"
+    assert Textbringer::TreeSitterConfig.parser_available?(language)
+    assert Textbringer::TreeSitter::NodeMaps.for(language)
+
+    erb_mode.extend(Textbringer::TreeSitterAdapter::ClassMethods)
+    erb_mode.use_tree_sitter(language)
+
+    assert_equal :"embedded-template", erb_mode.tree_sitter_language
+  ensure
+    Textbringer.send(:remove_const, :TestERBMode) if Textbringer.const_defined?(:TestERBMode)
+  end
+
   def test_tree_sitter_enabled_on_existing_mode
     skip "Markdown parser not installed" unless parser_available?(:markdown)
 

--- a/test/textbringer/tree_sitter/test_injection_maps_embedded_template.rb
+++ b/test/textbringer/tree_sitter/test_injection_maps_embedded_template.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "textbringer/tree_sitter/injection_maps"
+
+class InjectionMapsEmbeddedTemplateTest < Minitest::Test
+  def entries
+    Textbringer::TreeSitter::InjectionMaps.for(:"embedded-template")
+  end
+
+  def test_registers_embedded_template_injections
+    refute_nil entries
+  end
+
+  def test_directive_injects_ruby
+    entry = entries.find { |e| e[:node_type] == :directive }
+    assert_equal :code, entry[:content]
+    assert_equal :ruby, entry[:language]
+  end
+
+  def test_output_directive_injects_ruby
+    entry = entries.find { |e| e[:node_type] == :output_directive }
+    assert_equal :code, entry[:content]
+    assert_equal :ruby, entry[:language]
+  end
+
+  def test_content_self_injects_html
+    entry = entries.find { |e| e[:node_type] == :content }
+    assert_equal :content, entry[:content]
+    assert_equal :html, entry[:language]
+  end
+end

--- a/test/textbringer/tree_sitter/test_node_maps_embedded_template.rb
+++ b/test/textbringer/tree_sitter/test_node_maps_embedded_template.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "textbringer/tree_sitter/node_maps"
+
+class NodeMapsEmbeddedTemplateTest < Minitest::Test
+  def node_map
+    Textbringer::TreeSitter::NodeMaps.for(:"embedded-template")
+  end
+
+  def test_delimiters_mapped_to_keyword
+    assert_equal :keyword, node_map[:"<%"]
+    assert_equal :keyword, node_map[:"%>"]
+    assert_equal :keyword, node_map[:"<%="]
+  end
+
+  def test_comment_mapped
+    assert_equal :comment, node_map[:comment]
+  end
+
+  def test_code_and_content_left_unmapped_for_injection
+    # Highlighted via language injection instead (injection_maps/embedded_template.rb)
+    assert_nil node_map[:code]
+    assert_nil node_map[:content]
+  end
+end


### PR DESCRIPTION
## Summary
- Wires ERB highlighting on top of the injection engine (#78) via Faveod's embedded-template parser: Ruby code inside `<% %>`/`<%= %>`, HTML everywhere else
- **This PR targets `feat/injection-s2-ruby-heredoc` (#87) since neither #86 nor #87 are merged yet** — built on top since this needs the two-tier registry refactor from S2
- Adds a real capability to the injection engine: "self-injection" (`content == node_type`), needed because ERB's `content` nodes are plain-text leaves, not a wrapper around a separate child (unlike Ruby's `heredoc_body`/`heredoc_content` pair)
- Also fixes a real pre-existing bug: `Language.load` was called with a hyphenated name for the C symbol lookup, but tree-sitter symbols can't contain hyphens — verified empirically and against `ruby_tree_sitter`'s own convenience method. Fixed in both `get_parser` and `load_injected_parser`.
- Registers `ERBMode` for `.erb` files

## Test plan
- [x] `bundle exec rake test` — 172 runs, 0 failures
- [x] Manual: a buffer mixing `<html>`, `<% if %>`/`<% end %>`, and `<%= %>` correctly highlights Ruby keywords/variables and HTML tag regions against real installed parsers, independently and without crashing
- [x] Reviewed by codex-advisor/gemini-advisor/grok-advisor (150+ line diff gate) — no blocking issues across three independent passes

## Filed separately
- #88: `:property` face is never in any `HIGHLIGHT_LEVELS` tier by default — a real, pre-existing gap affecting HTMLMode (and others) discovered while verifying this diff, out of scope to fix here

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)