### PR TITLE
fix: Include :property in HIGHLIGHT_LEVELS (default level 2+)

### DIFF
--- a/lib/textbringer/tree_sitter_adapter.rb
+++ b/lib/textbringer/tree_sitter_adapter.rb
@@ -8,7 +8,7 @@ module Textbringer
     # Emacs-style 4-level highlighting
     HIGHLIGHT_LEVELS = [
       %i[comment string],                    # Level 1: minimal
-      %i[keyword type constant],             # Level 2: basic
+      %i[keyword type constant property],    # Level 2: basic
       %i[function_name variable number],     # Level 3: standard (default)
       %i[operator punctuation builtin]       # Level 4: everything
     ].freeze

--- a/test/textbringer/test_tree_sitter_adapter.rb
+++ b/test/textbringer/test_tree_sitter_adapter.rb
@@ -132,6 +132,7 @@ class TreeSitterAdapterTest < Minitest::Test
     assert_includes faces, :keyword
     assert_includes faces, :type
     assert_includes faces, :constant
+    assert_includes faces, :property
     refute_includes faces, :function_name
   end
 
@@ -146,6 +147,7 @@ class TreeSitterAdapterTest < Minitest::Test
     assert_includes faces, :function_name
     assert_includes faces, :variable
     assert_includes faces, :number
+    assert_includes faces, :property
     refute_includes faces, :operator
     refute_includes faces, :punctuation
   end


### PR DESCRIPTION
## Summary
- `:property` (used by html/bash/haml/hcl/json/sql/csharp/crystal/elixir/groovy/pascal/php node maps) was never listed in any `HIGHLIGHT_LEVELS` tier, so `enabled_faces` filtered it out at every level
- A fresh `HTMLMode` buffer produced **zero** highlights with default config, since `tag_name`/`element`/etc. all map to `:property`
- Added to Level 2 (alongside `keyword`/`type`/`constant`), so it's included at the default level 3

## Test plan
- [x] `bundle exec rake test` — 138 runs, 0 failures
- [x] Manual: `HTMLMode` on `"<html>\n"` now produces a `:property` highlight for the tag name, with default `CONFIG`

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)