### PR TITLE
perf: Cache parsed injected-content trees (Injection S4)

### DIFF
--- a/lib/textbringer/tree_sitter_adapter.rb
+++ b/lib/textbringer/tree_sitter_adapter.rb
@@ -249,7 +249,11 @@ module Textbringer
         text = source.byteslice(content_node.start_byte, content_node.end_byte - content_node.start_byte)
         return unless text
 
-        injected_tree = parser.parse_string(nil, text)
+        injected_tree = get_cached_injected_tree(language, text) || begin
+          parsed = parser.parse_string(nil, text)
+          cache_injected_tree(language, text, parsed) if parsed
+          parsed
+        end
         return unless injected_tree
 
         node_map = TreeSitter::NodeMaps.for(language)
@@ -277,6 +281,32 @@ module Textbringer
 
       def resolve_injection_language(language_spec, host_node, source)
         language_spec.respond_to?(:call) ? language_spec.call(host_node, source) : language_spec
+      end
+
+      # Caches parsed injected-content trees keyed by (language, content
+      # hash), LRU-capped like the primary tree cache (get_cached_tree/
+      # cache_tree above), so an unchanged injected region is never
+      # reparsed on subsequent highlight passes.
+      def get_cached_injected_tree(language, text)
+        @injected_tree_cache ||= {}
+        key = [language, text.hash]
+        entry = @injected_tree_cache[key]
+        return nil unless entry
+
+        # LRU refresh: delete and re-insert to move to the end
+        @injected_tree_cache.delete(key)
+        @injected_tree_cache[key] = entry
+        entry
+      end
+
+      def cache_injected_tree(language, text, tree)
+        @injected_tree_cache ||= {}
+        key = [language, text.hash]
+
+        @injected_tree_cache.delete(key)
+        @injected_tree_cache[key] = tree
+
+        @injected_tree_cache.shift if @injected_tree_cache.size > 10
       end
 
       def get_injected_parser(language)

--- a/test/test_tree_sitter_injection.rb
+++ b/test/test_tree_sitter_injection.rb
@@ -28,11 +28,15 @@ end
 FakeTree = Struct.new(:root_node)
 
 class FakeParser
+  attr_reader :call_count
+
   def initialize(tree)
     @tree = tree
+    @call_count = 0
   end
 
   def parse_string(_old_tree, _text)
+    @call_count += 1
     @tree
   end
 end
@@ -310,5 +314,60 @@ class TestTreeSitterInjection < Minitest::Test
 
     assert_equal Textbringer::Face[:keyword], ctx.highlight_on[5]
     assert_equal true, ctx.highlight_off[15]
+  end
+
+  def test_unchanged_injected_content_is_not_reparsed
+    Textbringer::TreeSitter::InjectionMaps.register(:ruby, sql_injection_map)
+    Textbringer::TreeSitter::NodeMaps.register(:sql, { select_kw: :keyword })
+
+    inner_text = "select_kw"
+    content = content_node(10, inner_text)
+    root = host_root(content)
+    fake_parser = FakeParser.new(FakeTree.new(FakeNode.new(:select_kw, 0, inner_text.bytesize)))
+    @mode.define_singleton_method(:get_injected_parser) { |_lang| fake_parser }
+
+    source = " " * 100
+    @mode.send(:highlight_injections, ctx_for(source), root, source, 0)
+    @mode.send(:highlight_injections, ctx_for(source), root, source, 0)
+
+    assert_equal 1, fake_parser.call_count
+  end
+
+  def test_changed_injected_content_is_reparsed
+    Textbringer::TreeSitter::InjectionMaps.register(:ruby, sql_injection_map)
+    Textbringer::TreeSitter::NodeMaps.register(:sql, { select_kw: :keyword })
+
+    fake_parser = FakeParser.new(FakeTree.new(FakeNode.new(:select_kw, 0, 9)))
+    @mode.define_singleton_method(:get_injected_parser) { |_lang| fake_parser }
+
+    prefix = " " * 10
+    content1 = content_node(10, "select_kw")
+    source1 = prefix + "select_kw" + (" " * 81)
+    @mode.send(:highlight_injections, ctx_for(source1), host_root(content1), source1, 0)
+
+    content2 = content_node(10, "update_kw")
+    source2 = prefix + "update_kw" + (" " * 81)
+    @mode.send(:highlight_injections, ctx_for(source2), host_root(content2), source2, 0)
+
+    assert_equal 2, fake_parser.call_count
+  end
+
+  def test_injected_tree_cache_is_bounded
+    Textbringer::TreeSitter::InjectionMaps.register(:ruby, sql_injection_map)
+    Textbringer::TreeSitter::NodeMaps.register(:sql, { select_kw: :keyword })
+
+    fake_parser = FakeParser.new(FakeTree.new(FakeNode.new(:select_kw, 0, 3)))
+    @mode.define_singleton_method(:get_injected_parser) { |_lang| fake_parser }
+
+    source = " " * 200
+    20.times do |i|
+      text = "kw#{i}"
+      content = content_node(10, text)
+      @mode.send(:highlight_injections, ctx_for(source), host_root(content), source, 0)
+    end
+
+    cache = @mode.instance_variable_get(:@injected_tree_cache)
+    refute_nil cache
+    assert_operator cache.size, :<=, 10
   end
 end


### PR DESCRIPTION
## Summary
- `highlight_single_injection` previously reparsed every injection's content on every highlight call, even when unchanged
- Adds an LRU cache (cap 10) keyed by `(language, content-hash)`, mirroring the primary tree cache (`get_cached_tree`/`cache_tree`) already used for the host document
- **This PR targets `feat/injection-s3-erb` (#89) since #86/#87/#89 aren't merged yet**

## Benchmark
50 Ruby heredocs with SQL content, real `ruby`+`sql` parsers: cold highlight ~13.5ms, warm (cache hit) ~2.1ms — ~6x faster on repeated highlight passes over unchanged content, which is the common case (most keystrokes only touch a small part of the buffer).

## Test plan
- [x] `bundle exec rake test` — 175 runs, 0 failures
- [x] TDD'd: unchanged content is not reparsed, changed content is reparsed, cache is bounded (20 distinct injected regions → cache size stays ≤ 10)
- [x] Manual cold-vs-warm benchmark (above) against real installed parsers

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)