### PR TITLE
feat: Automate node-map update PRs for new upstream node types

### DIFF
--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -85,8 +85,16 @@ jobs:
             # 現在の NodeMaps から定義済みノードを抽出
             node_map_file="lib/textbringer/tree_sitter/node_maps/${lang}.rb"
             if [[ -f "$node_map_file" ]]; then
-              # NodeMap の %i[...] からノードシンボルを抽出（defined? なども含める）
-              current_nodes=$(ruby -e 'content = File.read(ARGV[0], encoding: "UTF-8"); puts content.scan(/%i\[(.*?)\]/m).flat_map { |m| m[0].split(/\s+/) }.reject(&:empty?).uniq.sort' "$node_map_file")
+              # %i[...] の定義済みシンボルに加え、過去の実行で追記済みの
+              # "# NEW in ..." コメント提案（未昇格分）も「既知」として扱う。
+              # そうしないと、人間が %i[...] に昇格させるまで毎回同じ提案が
+              # 重複して積み上がってしまう。
+              current_nodes=$(ruby -e '
+                content = File.read(ARGV[0], encoding: "UTF-8")
+                mapped = content.scan(/%i\[(.*?)\]/m).flat_map { |m| m[0].split(/\s+/) }
+                suggested = content.scan(/^#\s+(\S+)\s*(?:=>|\()/).flatten
+                puts (mapped + suggested).reject(&:empty?).uniq.sort
+              ' "$node_map_file")
 
               # 差分を計算（upstream にあって current にないもの）
               new_nodes=$(comm -23 <(echo "$upstream_nodes") <(echo "$current_nodes") | grep -v '^$' || true)
@@ -95,6 +103,8 @@ jobs:
                 HAS_NEW_NODES="true"
                 count=$(echo "$new_nodes" | wc -l | tr -d ' ')
                 REPORT="${REPORT}\n### ${lang}\n\n${count} new node types found:\n\`\`\`\n${new_nodes}\n\`\`\`\n"
+                # 言語ごとの新規ノード一覧を保存（PR 作成ステップで利用）
+                echo "$new_nodes" > "tmp/grammars/${lang}-new-nodes.txt"
               fi
             fi
           done
@@ -107,8 +117,59 @@ jobs:
             echo "report_file=tmp/report.md" >> $GITHUB_OUTPUT
           fi
 
-      - name: Create Issue for new node types
+      - name: Append node-map suggestions and open PR
         if: steps.check.outputs.has_new_nodes == 'true'
+        id: node-map-pr
+        continue-on-error: true
+        run: |
+          RELEASE="auto-$(date +%Y-%m-%d)"
+          BRANCH="auto/node-map-sync"
+
+          for f in tmp/grammars/*-new-nodes.txt; do
+            [[ -f "$f" ]] || continue
+            lang="$(basename "$f" -new-nodes.txt)"
+            nodes=()
+            while IFS= read -r line; do
+              [[ -n "$line" ]] && nodes+=("$line")
+            done < "$f"
+            ruby scripts/append_node_map_suggestions.rb "$lang" "$RELEASE" "${nodes[@]}"
+          done
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Always branch from a clean main, regardless of what a previous
+          # step in this job left checked out.
+          git checkout main
+          git checkout -B "$BRANCH"
+          git add lib/textbringer/tree_sitter/node_maps/*.rb
+
+          if git diff --cached --quiet; then
+            echo "Nothing new to suggest (all findings already appended in a previous run)"
+            git checkout main
+            exit 0
+          fi
+
+          git commit -m "chore: Suggest node-map updates for new upstream node types (${RELEASE})"
+          git push -f origin "$BRANCH"
+
+          if [[ -n "$(gh pr list --head "$BRANCH" --state open --json number -q '.[0].number')" ]]; then
+            echo "PR already exists for $BRANCH"
+          else
+            gh pr create \
+              --title "chore: New upstream node types detected (${RELEASE})" \
+              --body "Automated node-map suggestions from the sync-upstream workflow. All suggested mappings are commented out -- review before uncommenting any of them." \
+              --head "$BRANCH" \
+              --base main
+          fi
+
+          # Leave the workspace back on main for any later steps in this job.
+          git checkout main
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Fall back to Issue if node-map PR creation failed
+        if: steps.check.outputs.has_new_nodes == 'true' && steps.node-map-pr.outcome == 'failure'
         uses: actions/github-script@v7
         with:
           script: |
@@ -118,7 +179,7 @@ jobs:
             const title = `[Auto] New upstream node types detected (${new Date().toISOString().split('T')[0]})`;
             const body = `## Upstream Grammar Sync Report
 
-            The following new node types were detected in upstream tree-sitter grammars:
+            The following new node types were detected in upstream tree-sitter grammars, but the automated node-map PR failed.
 
             ${report}
 
@@ -187,6 +248,10 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
+          # Always branch from a clean main, regardless of what a previous
+          # step in this job left checked out.
+          git checkout main
+
           BRANCH="auto/faveod-${LATEST}"
           git checkout -B "$BRANCH"
           git add .github/workflows/sync-upstream.yml \
@@ -194,10 +259,17 @@ jobs:
             scripts/build_parsers.sh \
             scripts/download_parsers.sh \
             exe/textbringer-tree-sitter
+
+          if git diff --cached --quiet; then
+            echo "Nothing to bump (already up to date)"
+            git checkout main
+            exit 0
+          fi
+
           git commit -m "chore: Bump Faveod/tree-sitter-parsers to ${LATEST}"
           git push -f origin "$BRANCH"
 
-          if gh pr view "$BRANCH" >/dev/null 2>&1; then
+          if [[ -n "$(gh pr list --head "$BRANCH" --state open --json number -q '.[0].number')" ]]; then
             echo "PR already exists for $BRANCH"
           else
             gh pr create \
@@ -206,6 +278,8 @@ jobs:
               --head "$BRANCH" \
               --base main
           fi
+
+          git checkout main
         env:
           GH_TOKEN: ${{ github.token }}
 

--- a/scripts/append_node_map_suggestions.rb
+++ b/scripts/append_node_map_suggestions.rb
@@ -1,0 +1,76 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Appends heuristic node-map suggestions (all commented out) for newly
+# detected upstream node types, so a human can review before enabling any
+# of them. See lib/textbringer/tree_sitter/node_maps/*.rb for the format
+# these suggestions are meant to be promoted into.
+
+def guess_face(node_name)
+  name = node_name.to_s.downcase
+  case name
+  when /comment/
+    :comment
+  when /string|heredoc|char_literal|template_string/
+    :string
+  when /number|integer|float|decimal|numeric/
+    :number
+  when /\b(if|else|elsif|unless|case|when|while|until|for|do|end|begin|rescue|ensure|return|yield|break|next|redo|retry|raise|class|module|def|alias|defined|super|self|nil|true|false|and|or|not|in|fn|func|function|let|const|var|import|export|from|as|try|catch|finally|throw|async|await|match|loop|struct|enum|impl|trait|pub|mut|ref|use|mod|crate|where|type|interface|package|extends|implements|static|final|abstract|native|synchronized|volatile|transient|new|this|instanceof|goto|switch|default|continue|assert|with|pass|lambda|nonlocal|global|del|except|exec|print|elif|is)\b/
+    :keyword
+  when /keyword|reserved/
+    :keyword
+  when /constant|boolean/
+    :constant
+  when /function_name|method_name|call|invocation/
+    :function_name
+  when /type|class_name|struct_name|interface_name/
+    :type
+  when /variable|identifier|name/
+    :variable
+  when /operator|binary_op|unary_op/
+    :operator
+  when /punctuation|delimiter|bracket|paren|brace/
+    :punctuation
+  when /marker|heading|header/
+    :keyword
+  else
+    nil
+  end
+end
+
+language = ARGV[0]
+release = ARGV[1]
+new_nodes = ARGV[2..] || []
+
+if language.nil? || release.nil?
+  warn "Usage: append_node_map_suggestions.rb <language> <release> <node_type>..."
+  exit 1
+end
+
+node_map_file = "lib/textbringer/tree_sitter/node_maps/#{language}.rb"
+
+unless File.exist?(node_map_file)
+  warn "Error: node map not found: #{node_map_file}"
+  exit 1
+end
+
+content = File.read(node_map_file)
+marker = "# NEW in #{release}"
+
+if content.include?(marker)
+  # Already appended for this release -- avoid duplicating on re-run.
+  exit 0
+end
+
+section = +"\n#{marker} (auto-suggested, review before enabling):\n"
+new_nodes.each do |node|
+  face = guess_face(node)
+  if face
+    section << "#   #{node} => :#{face}\n"
+  else
+    section << "#   #{node} (unmapped)\n"
+  end
+end
+
+File.write(node_map_file, content + section)
+puts "Appended #{new_nodes.size} suggestion(s) to #{node_map_file}"

--- a/test/test_append_node_map_suggestions.rb
+++ b/test/test_append_node_map_suggestions.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "open3"
+require "fileutils"
+require "tmpdir"
+
+class TestAppendNodeMapSuggestions < Minitest::Test
+  SCRIPT = File.expand_path("../scripts/append_node_map_suggestions.rb", __dir__)
+
+  def setup
+    @dir = Dir.mktmpdir
+    FileUtils.mkdir_p(File.join(@dir, "lib/textbringer/tree_sitter/node_maps"))
+    File.write(File.join(@dir, "lib/textbringer/tree_sitter/node_maps/ruby.rb"), <<~RUBY)
+      # frozen_string_literal: true
+
+      module Textbringer
+        module TreeSitter
+          module NodeMaps
+            RUBY_FEATURES = {
+              keyword: %i[def end],
+            }.freeze
+
+            RUBY = RUBY_FEATURES.flat_map { |face, nodes|
+              nodes.map { |node| [node, face] }
+            }.to_h.freeze
+          end
+        end
+      end
+    RUBY
+  end
+
+  def teardown
+    FileUtils.remove_entry(@dir)
+  end
+
+  def run_script(*args)
+    Open3.capture3("ruby", SCRIPT, *args, chdir: @dir)
+  end
+
+  def node_map_content
+    File.read(File.join(@dir, "lib/textbringer/tree_sitter/node_maps/ruby.rb"))
+  end
+
+  def test_appends_commented_suggestions_for_new_nodes
+    _out, err, status = run_script("ruby", "v27", "new_string_literal", "new_keyword_thing")
+    assert status.success?, "script should exit successfully, stderr: #{err}"
+
+    content = node_map_content
+    assert_match(/# NEW in v27/, content)
+    assert_match(/#\s*new_string_literal.*:string/, content)
+    assert_match(/#\s*new_keyword_thing.*:keyword/, content)
+  end
+
+  def test_all_suggested_entries_are_commented_out
+    run_script("ruby", "v27", "new_string_literal", "totally_unguessable_xyz")
+
+    content = node_map_content
+    marker_index = content.index("# NEW in v27")
+    new_section = content[marker_index..]
+    new_section.lines.each do |line|
+      next if line.strip.empty?
+
+      assert_match(/\A\s*#/, line, "expected every suggestion line to be commented out: #{line.inspect}")
+    end
+  end
+
+  def test_unguessable_node_marked_as_unmapped
+    run_script("ruby", "v27", "totally_unguessable_xyz")
+
+    content = node_map_content
+    assert_match(/totally_unguessable_xyz.*unmapped/, content)
+  end
+
+  def test_does_not_modify_existing_mapped_entries
+    original = node_map_content
+    run_script("ruby", "v27", "new_string_literal")
+
+    content = node_map_content
+    assert_includes content, "keyword: %i[def end]"
+    refute_equal original, content
+  end
+
+  def test_missing_node_map_file_errors_without_crashing
+    _out, err, status = run_script("nonexistent_lang", "v27", "some_node")
+    refute status.success?
+    assert_match(/not found|no such/i, err)
+  end
+
+  def test_rerun_does_not_duplicate_the_same_release_section
+    run_script("ruby", "v27", "new_string_literal")
+    run_script("ruby", "v27", "new_string_literal")
+
+    content = node_map_content
+    assert_equal 1, content.scan("# NEW in v27").size
+  end
+end


### PR DESCRIPTION
## Summary
- Mirrors the Faveod-bump automation (#71/PR #83): new upstream node types now produce a ready-to-review PR with commented-out heuristic suggestions instead of an issue
- **This PR targets `feat/automate-faveod-bump-pr` (#83) since it's not merged yet** — reuses its PR-creation plumbing
- `scripts/append_node_map_suggestions.rb`: appends a commented `# NEW in <release>` suggestion block per language, idempotent per release marker, TDD'd
- Workflow change: detection step now writes per-language new-node lists; a new step invokes the append script, commits/pushes to a fixed `auto/node-map-sync` branch, opens/reuses a PR, falls back to the original issue-creation behavior on failure

## Test plan
- [x] `bundle exec rake test` — 147 runs, 0 failures
- [x] Manually simulated the bash detection/append logic end-to-end against a temp fixture (see commit message)
- [x] Reviewed by codex-advisor/gemini-advisor/grok-advisor (150+ line diff gate) — real findings applied, including a critical fix: the new step was leaving the job's git workspace on a non-main branch, which would have silently corrupted the **existing** Faveod-bump step (running later in the same job) into branching from the wrong ref. See commit message for the full list of fixes (empty-commit guard, `gh pr list --state open` instead of `gh pr view`, duplicate-suggestion accumulation across runs).

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)